### PR TITLE
feat(topic): create entities - Topic & ResourceTopic 

### DIFF
--- a/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/ResourceSubTopic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/ResourceSubTopic.java
@@ -1,5 +1,6 @@
 package com.kllhy.roadmap.roadmap.persistence.model;
 
+import com.kllhy.roadmap.roadmap.persistence.model.enums.ResourceType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/ResourceTopic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/ResourceTopic.java
@@ -1,5 +1,6 @@
 package com.kllhy.roadmap.roadmap.persistence.model;
 
+import com.kllhy.roadmap.roadmap.persistence.model.enums.ResourceType;
 import jakarta.persistence.*;
 
 @Entity

--- a/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/ResourceTopic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/ResourceTopic.java
@@ -1,0 +1,30 @@
+package com.kllhy.roadmap.roadmap.persistence.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "resource_topic")
+public class ResourceTopic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    // To Do: ResourceTopic.name 제약 사항 결정(ex. 길이, not null?)
+    @Column(name = "name")
+    private String name;
+
+    // To Do: 효진님 PR(#3) 머지 후 rebase 해서 ResourceType 열거형 가져와야 함, 그 전까지 커밋하지 말 것
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ResourceType resourceType;
+
+    // To Do: sort_order 제약 사항 결정(ex. 0이상? 아니면 1이상?, ...)
+    @Column(name = "sort_order", nullable = false)
+    private Integer order;
+
+    // To Do: 안전한 링크인지 확인하는 기능도 있으면 괜찮을 것 같음
+    @Column(name = "link", nullable = false)
+    private String link;
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/ResourceTopic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/ResourceTopic.java
@@ -16,7 +16,6 @@ public class ResourceTopic {
     @Column(name = "name")
     private String name;
 
-    // To Do: 효진님 PR(#3) 머지 후 rebase 해서 ResourceType 열거형 가져와야 함, 그 전까지 커밋하지 말 것
     @Column(name = "type", nullable = false)
     @Enumerated(EnumType.STRING)
     private ResourceType resourceType;

--- a/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/SubTopic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/SubTopic.java
@@ -1,5 +1,6 @@
 package com.kllhy.roadmap.roadmap.persistence.model;
 
+import com.kllhy.roadmap.roadmap.persistence.model.enums.ImportanceLevel;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/Topic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/Topic.java
@@ -1,5 +1,6 @@
 package com.kllhy.roadmap.roadmap.persistence.model;
 
+import com.kllhy.roadmap.roadmap.persistence.model.enums.ImportanceLevel;
 import jakarta.persistence.*;
 
 import java.sql.Timestamp;

--- a/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/Topic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/Topic.java
@@ -2,7 +2,6 @@ package com.kllhy.roadmap.roadmap.persistence.model;
 
 import com.kllhy.roadmap.roadmap.persistence.model.enums.ImportanceLevel;
 import jakarta.persistence.*;
-
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,11 +16,7 @@ public class Topic {
     private Long id;
 
     // To Do: N+1 문제 주의!
-    @OneToMany(
-            cascade = CascadeType.ALL,
-            orphanRemoval = true,
-            fetch = FetchType.LAZY
-    )
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "topic_id", nullable = false)
     private List<ResourceTopic> resources = new ArrayList<>();
 

--- a/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/Topic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/Topic.java
@@ -28,7 +28,6 @@ public class Topic {
     @Column(name = "content")
     private String content;
 
-    // To Do: 효진님 PR(#3) 머지 후 rebase 해서 ResourceType 열거형 가져와야 함, 그 전까지 커밋하지 말 것
     @Column(name = "importance_level", nullable = false)
     @Enumerated(EnumType.STRING)
     private ImportanceLevel importanceLevel;

--- a/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/Topic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/Topic.java
@@ -1,0 +1,59 @@
+package com.kllhy.roadmap.roadmap.persistence.model;
+
+import jakarta.persistence.*;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "topic")
+public class Topic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    // To Do: N+1 문제 주의!
+    @OneToMany(
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    @JoinColumn(name = "topic_id", nullable = false)
+    private List<ResourceTopic> resources = new ArrayList<>();
+
+    // To Do: Topic.title 제약 사항 결정(ex. 길이)
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    // To Do: Topic.content 제약 사항 결정(ex. 길이)
+    @Column(name = "content")
+    private String content;
+
+    // To Do: 효진님 PR(#3) 머지 후 rebase 해서 ResourceType 열거형 가져와야 함, 그 전까지 커밋하지 말 것
+    @Column(name = "importance_level", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ImportanceLevel importanceLevel;
+
+    // To Do: Topic.orderInRoadMap 제약 사항 결정(ex. 0이상? 아니면 1이상?)
+    @Column(name = "order_in_roadmap", nullable = false)
+    private Integer order;
+
+    // To Do: 시간 순서 제약 사항 createdAt(nn) -> modifiedAt(nullable) -> deletedAt(nullable)
+    @Column(name = "created_at", nullable = false)
+    private Timestamp createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private Timestamp modifiedAt;
+
+    @Column(name = "deleted_at", nullable = false)
+    private Timestamp deletedAt;
+
+    @Column(name = "is_draft", nullable = false)
+    private boolean isDraft;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/enums/ImportanceLevel.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/enums/ImportanceLevel.java
@@ -1,4 +1,4 @@
-package com.kllhy.roadmap.roadmap.persistence.model;
+package com.kllhy.roadmap.roadmap.persistence.model.enums;
 
 public enum ImportanceLevel {
     DEFAULT,

--- a/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/enums/ResourceType.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/persistence/model/enums/ResourceType.java
@@ -1,4 +1,4 @@
-package com.kllhy.roadmap.roadmap.persistence.model;
+package com.kllhy.roadmap.roadmap.persistence.model.enums;
 
 public enum ResourceType {
     VIDEO,


### PR DESCRIPTION
## Summary
- 주제(`Topic`) 및 해당 주제의 학습 자료(`ResourceTopic`) 엔티티 정의

## Related Issue
- Issue Number: #6 

## Changes
- `Topic` 엔티티 클래스 추가
- `ResourceTopic` 엔티티 클래스 추가
- enum class 위치 이동: `ImportanceLevel`, `ResourceType`

## Discussion Topic
- `Topic` -> `ResourceTopic` 관계 방향: 양방향 vs 단방향
- fetch 방식 비교: eager vs lazy
- 로컬에서 lint 어떻게 하나요?

## What's Next?
- PR(#5 ) 머지된 후에, common 이용해서 기존 엔티티 클래스 변경해야 함
- Roadmap 엔티티 구현
- Domain Repository / JPA Repository 분리 구현
- CQRS 패턴 사용할 것인지 고민해보기

## Checklist
- [x] 로컬 테스트 완료
- [x] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음
