### PR TITLE
feat(roadmap): add service interface for external roadmap query 

### DIFF
--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/RoadMapQueryService.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/RoadMapQueryService.java
@@ -1,0 +1,9 @@
+package com.kllhy.roadmap.roadmap.application.query;
+
+import com.kllhy.roadmap.roadmap.application.query.dto.RoadMapView;
+
+public interface RoadMapQueryService {
+    RoadMapView findById(Long id);
+
+    boolean existsById(Long id);
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/ResourceSubTopicView.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/ResourceSubTopicView.java
@@ -1,6 +1,6 @@
 package com.kllhy.roadmap.roadmap.application.query.dto;
 
-import com.kllhy.roadmap.roadmap.persistence.model.enums.ResourceType;
+import com.kllhy.roadmap.roadmap.domain.model.enums.ResourceType;
 
 public record ResourceSubTopicView(
         long id, String name, ResourceType resourceType, int order, String link) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/ResourceSubTopicView.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/ResourceSubTopicView.java
@@ -1,0 +1,6 @@
+package com.kllhy.roadmap.roadmap.application.query.dto;
+
+import com.kllhy.roadmap.roadmap.persistence.model.enums.ResourceType;
+
+public record ResourceSubTopicView(
+        long id, String name, ResourceType resourceType, int order, String link) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/ResourceTopicView.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/ResourceTopicView.java
@@ -1,6 +1,6 @@
 package com.kllhy.roadmap.roadmap.application.query.dto;
 
-import com.kllhy.roadmap.roadmap.persistence.model.enums.ResourceType;
+import com.kllhy.roadmap.roadmap.domain.model.enums.ResourceType;
 
 public record ResourceTopicView(
         long id, String name, ResourceType resourceType, int order, String link) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/ResourceTopicView.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/ResourceTopicView.java
@@ -1,0 +1,6 @@
+package com.kllhy.roadmap.roadmap.application.query.dto;
+
+import com.kllhy.roadmap.roadmap.persistence.model.enums.ResourceType;
+
+public record ResourceTopicView(
+        long id, String name, ResourceType resourceType, int order, String link) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/RoadMapView.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/RoadMapView.java
@@ -1,0 +1,23 @@
+package com.kllhy.roadmap.roadmap.application.query.dto;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+public record RoadMapView(
+        long id,
+        String title,
+        String description,
+        Timestamp deletedAt,
+        Timestamp createdAt,
+        Timestamp modifiedAt,
+        boolean isDeleted,
+        boolean isDraft,
+        long categoryId,
+        List<TopicView> topics) {
+    public RoadMapView {
+        if (topics == null) {
+            throw new IllegalArgumentException("로드맵은 1개 이상의 토픽을 가짐");
+        }
+        topics = List.copyOf(topics);
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/SubTopicView.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/SubTopicView.java
@@ -1,0 +1,21 @@
+package com.kllhy.roadmap.roadmap.application.query.dto;
+
+import com.kllhy.roadmap.roadmap.persistence.model.enums.ImportanceLevel;
+import java.sql.Timestamp;
+import java.util.List;
+
+public record SubTopicView(
+        long id,
+        String title,
+        String content,
+        ImportanceLevel importanceLevel,
+        Timestamp deletedAt,
+        boolean isDraft,
+        boolean isDeleted,
+        List<ResourceSubTopicView> resources,
+        Timestamp createdAt,
+        Timestamp modifiedAt) {
+    public SubTopicView {
+        resources = List.copyOf(resources);
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/SubTopicView.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/SubTopicView.java
@@ -1,6 +1,6 @@
 package com.kllhy.roadmap.roadmap.application.query.dto;
 
-import com.kllhy.roadmap.roadmap.persistence.model.enums.ImportanceLevel;
+import com.kllhy.roadmap.roadmap.domain.model.enums.ImportanceLevel;
 import java.sql.Timestamp;
 import java.util.List;
 

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/TopicView.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/TopicView.java
@@ -1,0 +1,24 @@
+package com.kllhy.roadmap.roadmap.application.query.dto;
+
+import com.kllhy.roadmap.roadmap.persistence.model.enums.ImportanceLevel;
+import java.sql.Timestamp;
+import java.util.List;
+
+public record TopicView(
+        long id,
+        List<ResourceTopicView> resources,
+        List<SubTopicView> subTopics,
+        String title,
+        String content,
+        ImportanceLevel importanceLevel,
+        int order,
+        Timestamp createdAt,
+        Timestamp modifiedAt,
+        Timestamp deletedAt,
+        boolean isDraft,
+        boolean isDeleted) {
+    public TopicView {
+        resources = List.copyOf(resources);
+        subTopics = List.copyOf(subTopics);
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/TopicView.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/dto/TopicView.java
@@ -1,6 +1,6 @@
 package com.kllhy.roadmap.roadmap.application.query.dto;
 
-import com.kllhy.roadmap.roadmap.persistence.model.enums.ImportanceLevel;
+import com.kllhy.roadmap.roadmap.domain.model.enums.ImportanceLevel;
 import java.sql.Timestamp;
 import java.util.List;
 


### PR DESCRIPTION
## Summary
- 외부 도메인에서 로드맵을 조회할 수 있는 인터페이스를 추가
- 로드맵 조회시 읽기 전용 객체로 전달됨

## Related Issue
- Issue Number: #28 
- (선택) Closes #28 

## Discussion Topic
- 읽기 전용 객체는 id, order 값 등이 이미 정해진 상태이므로 필드 선언시 premitive typ으로 선언했습니다 

## Checklist
- [ ] 로컬 테스트 완료
- [x] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음
