### PR TITLE
feat(roadMap): Add road map domain event logic

### DIFF
--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandService.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandService.java
@@ -1,0 +1,7 @@
+package com.kllhy.roadmap.roadmap.application.command;
+
+import com.kllhy.roadmap.roadmap.domain.model.update_spec.UpdateRoadMap;
+
+public interface RoadMapCommandService {
+    void update(long roadMapId, UpdateRoadMap updateRoadMap);
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandServiceAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandServiceAdapter.java
@@ -1,0 +1,27 @@
+package com.kllhy.roadmap.roadmap.application.command;
+
+import com.kllhy.roadmap.common.exception.DomainException;
+import com.kllhy.roadmap.roadmap.domain.exception.RoadMapIErrorCode;
+import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
+import com.kllhy.roadmap.roadmap.domain.model.update_spec.UpdateRoadMap;
+import com.kllhy.roadmap.roadmap.domain.repository.RoadMapRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RoadMapCommandServiceAdapter implements RoadMapCommandService {
+
+    private final RoadMapRepository roadMapRepository;
+
+    @Override
+    public void update(long roadMapId, UpdateRoadMap updateRoadMap) {
+        RoadMap roadMap =
+                roadMapRepository
+                        .findById(roadMapId)
+                        .orElseThrow(() -> new DomainException(RoadMapIErrorCode.ROAD_MAP_BAD_REQUEST));
+        roadMap.update(updateRoadMap);
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandServiceAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandServiceAdapter.java
@@ -21,7 +21,8 @@ public class RoadMapCommandServiceAdapter implements RoadMapCommandService {
         RoadMap roadMap =
                 roadMapRepository
                         .findById(roadMapId)
-                        .orElseThrow(() -> new DomainException(RoadMapIErrorCode.ROAD_MAP_BAD_REQUEST));
+                        .orElseThrow(
+                                () -> new DomainException(RoadMapIErrorCode.ROAD_MAP_BAD_REQUEST));
         roadMap.update(updateRoadMap);
     }
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/event/RoadMapEventOccurred.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/event/RoadMapEventOccurred.java
@@ -3,7 +3,6 @@ package com.kllhy.roadmap.roadmap.domain.event;
 import com.kllhy.roadmap.common.event.BaseDomainEvent;
 import com.kllhy.roadmap.roadmap.domain.event.enums.ActiveStatus;
 import com.kllhy.roadmap.roadmap.domain.event.enums.EventType;
-
 import java.util.UUID;
 
 public class RoadMapEventOccurred extends BaseDomainEvent {

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/event/RoadMapEventOccurred.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/event/RoadMapEventOccurred.java
@@ -4,20 +4,22 @@ import com.kllhy.roadmap.common.event.BaseDomainEvent;
 import com.kllhy.roadmap.roadmap.domain.event.enums.ActiveStatus;
 import com.kllhy.roadmap.roadmap.domain.event.enums.EventType;
 
+import java.util.UUID;
+
 public class RoadMapEventOccurred extends BaseDomainEvent {
 
-    private final Long roadMapId;
+    private final UUID roadMapUUID;
     private final EventType eventType;
     private final ActiveStatus activeStatus;
 
-    public RoadMapEventOccurred(Long roadMapId, EventType eventType, ActiveStatus activeStatus) {
-        this.roadMapId = roadMapId;
+    public RoadMapEventOccurred(UUID roadMapUUID, EventType eventType, ActiveStatus activeStatus) {
+        this.roadMapUUID = roadMapUUID;
         this.eventType = eventType;
         this.activeStatus = activeStatus;
     }
 
-    public Long roadMapId() {
-        return roadMapId;
+    public UUID roadMapUUID() {
+        return roadMapUUID;
     }
 
     public EventType eventType() {

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/event/SubTopicEventOccurred.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/event/SubTopicEventOccurred.java
@@ -3,7 +3,6 @@ package com.kllhy.roadmap.roadmap.domain.event;
 import com.kllhy.roadmap.common.event.BaseDomainEvent;
 import com.kllhy.roadmap.roadmap.domain.event.enums.ActiveStatus;
 import com.kllhy.roadmap.roadmap.domain.event.enums.EventType;
-
 import java.util.UUID;
 
 public class SubTopicEventOccurred extends BaseDomainEvent {

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/event/SubTopicEventOccurred.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/event/SubTopicEventOccurred.java
@@ -4,37 +4,39 @@ import com.kllhy.roadmap.common.event.BaseDomainEvent;
 import com.kllhy.roadmap.roadmap.domain.event.enums.ActiveStatus;
 import com.kllhy.roadmap.roadmap.domain.event.enums.EventType;
 
+import java.util.UUID;
+
 public class SubTopicEventOccurred extends BaseDomainEvent {
 
-    private final Long roadMapId;
-    private final Long topicId;
-    private final Long subTopicId;
+    private final UUID roadMapUUID;
+    private final UUID topicUUID;
+    private final UUID subTopicUUID;
     private final EventType eventType;
     private final ActiveStatus activeStatus;
 
     public SubTopicEventOccurred(
-            Long roadMapId,
-            Long topicId,
-            Long subTopicId,
+            UUID roadMapUUID,
+            UUID topicUUID,
+            UUID subTopicUUID,
             EventType eventType,
             ActiveStatus activeStatus) {
-        this.roadMapId = roadMapId;
-        this.topicId = topicId;
-        this.subTopicId = subTopicId;
+        this.roadMapUUID = roadMapUUID;
+        this.topicUUID = topicUUID;
+        this.subTopicUUID = subTopicUUID;
         this.eventType = eventType;
         this.activeStatus = activeStatus;
     }
 
-    public Long roadMapId() {
-        return roadMapId;
+    public UUID roadMapUUID() {
+        return roadMapUUID;
     }
 
-    public Long topicId() {
-        return topicId;
+    public UUID topicUUID() {
+        return topicUUID;
     }
 
-    public Long subTopicId() {
-        return subTopicId;
+    public UUID subTopicUUID() {
+        return subTopicUUID;
     }
 
     public EventType eventType() {

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/event/TopicEventOccurred.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/event/TopicEventOccurred.java
@@ -3,7 +3,6 @@ package com.kllhy.roadmap.roadmap.domain.event;
 import com.kllhy.roadmap.common.event.BaseDomainEvent;
 import com.kllhy.roadmap.roadmap.domain.event.enums.ActiveStatus;
 import com.kllhy.roadmap.roadmap.domain.event.enums.EventType;
-
 import java.util.UUID;
 
 public class TopicEventOccurred extends BaseDomainEvent {

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/event/TopicEventOccurred.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/event/TopicEventOccurred.java
@@ -4,27 +4,29 @@ import com.kllhy.roadmap.common.event.BaseDomainEvent;
 import com.kllhy.roadmap.roadmap.domain.event.enums.ActiveStatus;
 import com.kllhy.roadmap.roadmap.domain.event.enums.EventType;
 
+import java.util.UUID;
+
 public class TopicEventOccurred extends BaseDomainEvent {
 
-    private final Long roadMapId;
-    private final Long topicId;
+    private final UUID roadMapUUID;
+    private final UUID topicUUID;
     private final EventType eventType;
     private final ActiveStatus activeStatus;
 
     public TopicEventOccurred(
-            Long roadMapId, Long topicId, EventType eventType, ActiveStatus activeStatus) {
-        this.roadMapId = roadMapId;
-        this.topicId = topicId;
+            UUID roadMapUUID, UUID topicUUID, EventType eventType, ActiveStatus activeStatus) {
+        this.roadMapUUID = roadMapUUID;
+        this.topicUUID = topicUUID;
         this.eventType = eventType;
         this.activeStatus = activeStatus;
     }
 
-    public Long roadMapId() {
-        return roadMapId;
+    public UUID roadMapUUID() {
+        return roadMapUUID;
     }
 
-    public Long topicId() {
-        return topicId;
+    public UUID topicUUID() {
+        return topicUUID;
     }
 
     public EventType eventType() {

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 public class RoadMap extends AggregateRoot {
 
     @Column(name = "uuid", nullable = false, unique = true)
+    @Getter
     private UUID uuid;
 
     @Column(name = "title", nullable = false)

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
@@ -17,6 +17,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RoadMap extends AggregateRoot {
 
+    @Column(name = "uuid", nullable = false, unique = true)
+    private UUID uuid;
+
     @Column(name = "title", nullable = false)
     @Getter
     private String title;
@@ -48,11 +51,13 @@ public class RoadMap extends AggregateRoot {
     private List<Topic> topics = new ArrayList<>();
 
     private RoadMap(
+            UUID uuid,
             String title,
             String description,
             boolean isDraft,
             Long categoryId,
             List<Topic> topics) {
+        this.uuid = uuid;
         this.title = title;
         this.description = description;
         this.isDraft = isDraft;
@@ -80,6 +85,7 @@ public class RoadMap extends AggregateRoot {
 
         RoadMap created =
                 new RoadMap(
+                        UUID.randomUUID(),
                         title,
                         description,
                         creationSpec.isDraft(),

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
@@ -108,24 +108,36 @@ public class RoadMap extends AggregateRoot {
     }
 
     private static void addCreateOrUpdateEvents(RoadMap created) {
-        ActiveStatus roadMapActiveStatus = created.isDraft ? ActiveStatus.INACTIVE : ActiveStatus.ACTIVE;
-        EventType roadMapEventType = created.getId() == null ? EventType.CREATED : EventType.UPDATED;
-        created.addDomainEvent(new RoadMapEventOccurred(
-                created.uuid, roadMapEventType, roadMapActiveStatus));
+        ActiveStatus roadMapActiveStatus =
+                created.isDraft ? ActiveStatus.INACTIVE : ActiveStatus.ACTIVE;
+        EventType roadMapEventType =
+                created.getId() == null ? EventType.CREATED : EventType.UPDATED;
+        created.addDomainEvent(
+                new RoadMapEventOccurred(created.uuid, roadMapEventType, roadMapActiveStatus));
 
         for (Topic topic : created.topics) {
             // Topic Event
-            ActiveStatus topicActiveStatus = topic.isDraft() ? ActiveStatus.INACTIVE : ActiveStatus.ACTIVE;
-            EventType topicEventType = topic.getId() == null ? EventType.CREATED : EventType.UPDATED;
-            created.addDomainEvent(new TopicEventOccurred(
-                    created.uuid, topic.getUuid(), topicEventType, topicActiveStatus));
+            ActiveStatus topicActiveStatus =
+                    topic.isDraft() ? ActiveStatus.INACTIVE : ActiveStatus.ACTIVE;
+            EventType topicEventType =
+                    topic.getId() == null ? EventType.CREATED : EventType.UPDATED;
+            created.addDomainEvent(
+                    new TopicEventOccurred(
+                            created.uuid, topic.getUuid(), topicEventType, topicActiveStatus));
 
             // SubTopic Event
             for (SubTopic subTopic : topic.getSubTopics()) {
-                ActiveStatus subTopicActiveStatus = subTopic.getIsDraft() ? ActiveStatus.INACTIVE : ActiveStatus.ACTIVE;
-                EventType subTopicEventType = subTopic.getId() == null ? EventType.CREATED : EventType.UPDATED;
-                created.addDomainEvent(new SubTopicEventOccurred(
-                        created.uuid, topic.getUuid(), subTopic.getUuid(), EventType.CREATED, ActiveStatus.ACTIVE));
+                ActiveStatus subTopicActiveStatus =
+                        subTopic.getIsDraft() ? ActiveStatus.INACTIVE : ActiveStatus.ACTIVE;
+                EventType subTopicEventType =
+                        subTopic.getId() == null ? EventType.CREATED : EventType.UPDATED;
+                created.addDomainEvent(
+                        new SubTopicEventOccurred(
+                                created.uuid,
+                                topic.getUuid(),
+                                subTopic.getUuid(),
+                                EventType.CREATED,
+                                ActiveStatus.ACTIVE));
             }
         }
     }
@@ -151,21 +163,23 @@ public class RoadMap extends AggregateRoot {
                         .filter(topic -> topic.getId() != null)
                         .collect(Collectors.toMap(Topic::getId, topic -> topic));
 
-        List<Topic> sortedUpdatedTopics = updateSpec.updateTopics().stream()
-                .sorted(Comparator.comparing(UpdateTopic::order))
-                .map(spec -> {
-                        if (spec.id() != null) {
-                            Topic existing = remainingTopics.remove(spec.id());
-                            if (existing == null) {
-                                throw new IllegalArgumentException(
-                                        "RoadMap.update: 존재하지 않는 Topic id 입니다.");
-                            }
-                            existing.update(spec);
-                            return existing;
-                        }
-                        return Topic.create(spec);
-                })
-                .toList();
+        List<Topic> sortedUpdatedTopics =
+                updateSpec.updateTopics().stream()
+                        .sorted(Comparator.comparing(UpdateTopic::order))
+                        .map(
+                                spec -> {
+                                    if (spec.id() != null) {
+                                        Topic existing = remainingTopics.remove(spec.id());
+                                        if (existing == null) {
+                                            throw new IllegalArgumentException(
+                                                    "RoadMap.update: 존재하지 않는 Topic id 입니다.");
+                                        }
+                                        existing.update(spec);
+                                        return existing;
+                                    }
+                                    return Topic.create(spec);
+                                })
+                        .toList();
 
         validateTopics(sortedUpdatedTopics);
         topics = sortedUpdatedTopics;

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/SubTopic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/SubTopic.java
@@ -19,6 +19,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SubTopic extends IdAuditEntity {
 
+    @Column(name = "uuid", nullable = false, unique = true)
+    private UUID uuid;
+
     @Column(nullable = false)
     @Getter
     private String title;
@@ -55,12 +58,14 @@ public class SubTopic extends IdAuditEntity {
     @OrderBy("order ASC")
     private List<ResourceSubTopic> resources = new ArrayList<>();
 
-    public SubTopic(
+    private SubTopic(
+            UUID uuid,
             String title,
             String content,
             ImportanceLevel importanceLevel,
             Boolean isDraft,
             List<ResourceSubTopic> resources) {
+        this.uuid = uuid;
         this.title = title;
         this.content = content;
         this.importanceLevel = importanceLevel;
@@ -89,6 +94,7 @@ public class SubTopic extends IdAuditEntity {
 
         SubTopic created =
                 new SubTopic(
+                        UUID.randomUUID(),
                         title,
                         creationSpec.content(),
                         creationSpec.importanceLevel(),
@@ -115,6 +121,7 @@ public class SubTopic extends IdAuditEntity {
 
         SubTopic created =
                 new SubTopic(
+                        UUID.randomUUID(),
                         updateSpec.title(),
                         updateSpec.content(),
                         updateSpec.importanceLevel(),

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/SubTopic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/SubTopic.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 public class SubTopic extends IdAuditEntity {
 
     @Column(name = "uuid", nullable = false, unique = true)
+    @Getter
     private UUID uuid;
 
     @Column(nullable = false)

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/Topic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/Topic.java
@@ -19,6 +19,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Topic extends IdAuditEntity {
 
+    @Column(name = "uuid", nullable = false, unique = true)
+    private UUID uuid;
+
     @Column(name = "title", nullable = false)
     @Getter
     private String title;
@@ -68,6 +71,7 @@ public class Topic extends IdAuditEntity {
     private List<SubTopic> subTopics = new ArrayList<>();
 
     private Topic(
+            UUID uuid,
             String title,
             String content,
             ImportanceLevel importanceLevel,
@@ -75,6 +79,7 @@ public class Topic extends IdAuditEntity {
             boolean isDraft,
             List<ResourceTopic> resources,
             List<SubTopic> subTopics) {
+        this.uuid = uuid;
         this.title = title;
         this.content = content;
         this.importanceLevel = importanceLevel;
@@ -112,6 +117,7 @@ public class Topic extends IdAuditEntity {
 
         Topic created =
                 new Topic(
+                        UUID.randomUUID(),
                         title,
                         content,
                         creationSpec.importanceLevel(),
@@ -147,6 +153,7 @@ public class Topic extends IdAuditEntity {
 
         Topic created =
                 new Topic(
+                        UUID.randomUUID(),
                         updateSpec.title(),
                         updateSpec.content(),
                         updateSpec.importanceLevel(),

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/Topic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/Topic.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 public class Topic extends IdAuditEntity {
 
     @Column(name = "uuid", nullable = false, unique = true)
+    @Getter
     private UUID uuid;
 
     @Column(name = "title", nullable = false)

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/RoadMapJpaRepository.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/RoadMapJpaRepository.java
@@ -1,6 +1,0 @@
-package com.kllhy.roadmap.roadmap.infrastructure;
-
-import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface RoadMapJpaRepository extends JpaRepository<RoadMap, Long> {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepository.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepository.java
@@ -1,0 +1,18 @@
+package com.kllhy.roadmap.roadmap.infrastructure.jpa;
+
+import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoadMapJpaRepository extends JpaRepository<RoadMap, Long> {
+
+    @EntityGraph(attributePaths = {
+            "topics",
+            "topics.resources",
+            "topics.subTopics",
+            "topics.subTopics.resources"
+    })
+    Optional<RoadMap> findByIdWithAssociations(Long id);
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepository.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepository.java
@@ -1,18 +1,18 @@
 package com.kllhy.roadmap.roadmap.infrastructure.jpa;
 
 import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface RoadMapJpaRepository extends JpaRepository<RoadMap, Long> {
 
-    @EntityGraph(attributePaths = {
-            "topics",
-            "topics.resources",
-            "topics.subTopics",
-            "topics.subTopics.resources"
-    })
+    @EntityGraph(
+            attributePaths = {
+                "topics",
+                "topics.resources",
+                "topics.subTopics",
+                "topics.subTopics.resources"
+            })
     Optional<RoadMap> findByIdWithAssociations(Long id);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
@@ -1,4 +1,4 @@
-package com.kllhy.roadmap.roadmap.infrastructure;
+package com.kllhy.roadmap.roadmap.infrastructure.jpa;
 
 import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
 import com.kllhy.roadmap.roadmap.domain.repository.RoadMapRepository;
@@ -20,5 +20,9 @@ public class RoadMapJpaRepositoryAdapter implements RoadMapRepository {
     @Override
     public boolean existsById(long id) {
         return roadMapJpaRepository.existsById(id);
+    }
+
+    public Optional<RoadMap> findByIdWithAssociations(long id) {
+        return roadMapJpaRepository.findByIdWithAssociations(id);
     }
 }

--- a/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapUpdateTest.java
+++ b/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapUpdateTest.java
@@ -1,19 +1,18 @@
 package com.kllhy.roadmap.roadmap.domain.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.kllhy.roadmap.roadmap.domain.model.creation_spec.*;
 import com.kllhy.roadmap.roadmap.domain.model.enums.ImportanceLevel;
 import com.kllhy.roadmap.roadmap.domain.model.enums.ResourceType;
 import com.kllhy.roadmap.roadmap.domain.model.update_spec.*;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import java.lang.reflect.Field;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 public class RoadMapUpdateTest {
 
@@ -174,8 +173,7 @@ public class RoadMapUpdateTest {
                                                                         "서브 리소스",
                                                                         1,
                                                                         ResourceType.POST,
-                                                                        "https://sub.example.com"))))
-                                )));
+                                                                        "https://sub.example.com")))))));
 
         return RoadMap.create(creationSpec);
     }

--- a/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapUpdateTest.java
+++ b/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapUpdateTest.java
@@ -1,0 +1,200 @@
+package com.kllhy.roadmap.roadmap.domain.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.kllhy.roadmap.roadmap.domain.model.creation_spec.*;
+import com.kllhy.roadmap.roadmap.domain.model.enums.ImportanceLevel;
+import com.kllhy.roadmap.roadmap.domain.model.enums.ResourceType;
+import com.kllhy.roadmap.roadmap.domain.model.update_spec.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class RoadMapUpdateTest {
+
+    @Test
+    @DisplayName("로드맵 업데이트 시 기존 토픽과 리소스를 비교하여 동기화한다")
+    void updateRoadMapSynchronizesAggregate() throws Exception {
+        RoadMap roadMap = createInitialRoadMap();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        String prettyJson = objectMapper.writeValueAsString(roadMap);
+        System.out.println(prettyJson);
+
+        Topic existingTopic = roadMap.getTopics().get(0);
+        setId(existingTopic, 100L);
+        ResourceTopic existingResource = existingTopic.getResources().get(0);
+        setId(existingResource, 200L);
+        SubTopic existingSubTopic = existingTopic.getSubTopics().get(0);
+        setId(existingSubTopic, 300L);
+        ResourceSubTopic existingSubResource = existingSubTopic.getResources().get(0);
+        setId(existingSubResource, 400L);
+
+        UpdateRoadMap updateSpec =
+                new UpdateRoadMap(
+                        "업데이트된 로드맵",
+                        "새로운 설명",
+                        true,
+                        2L,
+                        List.of(
+                                new UpdateTopic(
+                                        100L,
+                                        "토픽 1-수정",
+                                        "내용 수정",
+                                        ImportanceLevel.RECOMMENDED,
+                                        1,
+                                        true,
+                                        List.of(
+                                                new UpdateResourceTopic(
+                                                        200L,
+                                                        "자료 수정",
+                                                        1,
+                                                        ResourceType.POST,
+                                                        "https://resource.example"),
+                                                new UpdateResourceTopic(
+                                                        null,
+                                                        "새 자료",
+                                                        2,
+                                                        ResourceType.VIDEO,
+                                                        "https://video.example")),
+                                        List.of(
+                                                new UpdateSubTopic(
+                                                        300L,
+                                                        "서브토픽 수정",
+                                                        "서브 내용",
+                                                        ImportanceLevel.OPTIONAL,
+                                                        true,
+                                                        List.of(
+                                                                new UpdateResourceSubTopic(
+                                                                        400L,
+                                                                        "서브 리소스 수정",
+                                                                        1,
+                                                                        ResourceType.OFFICIAL,
+                                                                        "https://sub.example"))))),
+                                new UpdateTopic(
+                                        null,
+                                        "토픽 2",
+                                        "두 번째",
+                                        ImportanceLevel.DEFAULT,
+                                        2,
+                                        false,
+                                        List.of(),
+                                        List.of())));
+
+        roadMap.update(updateSpec);
+
+        assertThat(roadMap.getTitle()).isEqualTo("업데이트된 로드맵");
+        assertThat(roadMap.getCategoryId()).isEqualTo(2L);
+        assertThat(roadMap.getTopics()).hasSize(2);
+
+        Topic updatedTopic = roadMap.getTopics().get(0);
+        assertThat(updatedTopic.getId()).isEqualTo(100L);
+        assertThat(updatedTopic.getTitle()).isEqualTo("토픽 1-수정");
+        assertThat(updatedTopic.getResources()).hasSize(2);
+        assertThat(updatedTopic.getResources().get(0).getId()).isEqualTo(200L);
+        assertThat(updatedTopic.getResources().get(0).getName()).isEqualTo("자료 수정");
+        assertThat(updatedTopic.getResources().get(1).getId()).isNull();
+
+        SubTopic updatedSubTopic = updatedTopic.getSubTopics().get(0);
+        assertThat(updatedSubTopic.getId()).isEqualTo(300L);
+        assertThat(updatedSubTopic.getTitle()).isEqualTo("서브토픽 수정");
+        assertThat(updatedSubTopic.getResources()).hasSize(1);
+        assertThat(updatedSubTopic.getResources().get(0).getId()).isEqualTo(400L);
+        assertThat(updatedSubTopic.getResources().get(0).getName()).isEqualTo("서브 리소스 수정");
+
+        Topic newTopic = roadMap.getTopics().get(1);
+        assertThat(newTopic.getId()).isNull();
+        assertThat(newTopic.getTitle()).isEqualTo("토픽 2");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 토픽 ID로 업데이트하면 예외가 발생한다")
+    void updateRoadMapWithUnknownTopicId() throws Exception {
+        RoadMap roadMap = createInitialRoadMap();
+        Topic existingTopic = roadMap.getTopics().get(0);
+        setId(existingTopic, 10L);
+
+        UpdateRoadMap updateSpec =
+                new UpdateRoadMap(
+                        "잘못된 로드맵",
+                        "desc",
+                        false,
+                        1L,
+                        List.of(
+                                new UpdateTopic(
+                                        99L,
+                                        "존재하지 않는",
+                                        null,
+                                        ImportanceLevel.DEFAULT,
+                                        1,
+                                        false,
+                                        List.of(),
+                                        List.of())));
+
+        assertThatThrownBy(() -> roadMap.update(updateSpec))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("존재하지 않는 Topic id");
+    }
+
+    private RoadMap createInitialRoadMap() {
+        CreationRoadMap creationSpec =
+                new CreationRoadMap(
+                        "로드맵",
+                        "설명",
+                        false,
+                        1L,
+                        1L,
+                        List.of(
+                                new CreationTopic(
+                                        "토픽 1",
+                                        "내용",
+                                        ImportanceLevel.RECOMMENDED,
+                                        1,
+                                        false,
+                                        List.of(
+                                                new CreationResourceTopic(
+                                                        "자료",
+                                                        ResourceType.POST,
+                                                        1,
+                                                        "https://example.com")),
+                                        List.of(
+                                                new CreationSubTopic(
+                                                        "서브토픽",
+                                                        "서브 내용",
+                                                        ImportanceLevel.RECOMMENDED,
+                                                        false,
+                                                        List.of(
+                                                                new CreationResourceSubTopic(
+                                                                        "서브 리소스",
+                                                                        1,
+                                                                        ResourceType.POST,
+                                                                        "https://sub.example.com"))))
+                                )));
+
+        return RoadMap.create(creationSpec);
+    }
+
+    private void setId(Object target, long id) throws Exception {
+        Field field = findIdField(target.getClass());
+        field.setAccessible(true);
+        field.set(target, id);
+    }
+
+    private Field findIdField(Class<?> type) throws NoSuchFieldException {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                return current.getDeclaredField("id");
+            } catch (NoSuchFieldException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException("id");
+    }
+}


### PR DESCRIPTION
## Summary
[변경점 요약]
- 어제 만들었던 로드맵 도메인 이벤트 3가지는 지금부터 id 가 아닌 UUID 를 가집니다.

## 변경 의도
[현재 문제 상황]
- 도메인 이벤트에 DB 대리키를 넣어주어야 함
- DB 대리키의 경우 JPA 를 통해 영속화가 완료되어야 설정되므로 도메인(루트) 엔티티에서 발생시키는 것은 무리가 있음

[고려했던 대안]
1. 도메인 이벤트에서 DB 대리키 제거 후 비즈니스 키 사용하는 방법
2. 도메인 이벤트와 영속 이벤트를 분리
   - 도메인 엔티티에 이벤트 리스너(@EntityEventListner(...) 등록 후 @PostPersist 사용해서 영속화 후 이벤트 생성 및 발행
3. 도메인 생성 이벤트를 서비스 계층에서 직접 생성 후 발행(save & flush 이후에)

[결정한 방식]
1. 도메인 이벤트에 DB 대리키를 빼고, UUID 로 대체(마땅한 비즈니스 키가 없어서 UUID 를 만듭니다.)
   - UUID 는 각 엔티티 정적 팩토리 메서드에서 자체적으로 초기화하기 때문에 생성 시 외부에서 신경 쓸 필요는 없습니다.

[주요 이유]
- 2번 방식 반려 이유: 우리 팀이 프로젝트를 설계한 방향성 자체가 도메인을 특정 기술에 종속되지 않게 만들자는 것이었습니다. 이를 고려했을 때 엔티티 자체에 JPA 생명주기와 관련한 이벤트를 감지하는 이벤트 리스너를 등록하는 것은, 도메인이 특정 기술(JPA)에 강하게 결합되도록 만듭니다.
- 3번 방식 반려 이유: 서비스 로직이 다소 복잡해질 수 있고, flush 호출의 부적절하다는 효진님의 의견이 있었습니다.

## Related Issue
- Issue Number: #62 

## Changes
- `RoadMap`, `Topic`, `SubTopic` 에 `UUID` 유일키 추가
- `RoadMapEventOccurred`, `TopicEventOccurred`, `SubTopicEventOccurred` 이벤트의 id 값들을 전부 UUID 로 변경
- `RoadMap` - `Topic` - `SubTopic` 관계 그래프를 탐색하며 도메인 이벤트를 추가하는 로직 작성

## Discussion Topic
- 삭제 이벤트의 경우 서비스 레이어에서 처리하거나
- 엔티티에 JPA 생명주기와 연동된 이벤트 리스너를 등록해야 합니다.

## Checklist
- [ ] 로컬 테스트 완료
- [x] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음
