### PR TITLE
refactor&feat(starRoadMap) : command and query service methods for star roadmap operations

### DIFF
--- a/src/main/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandService.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandService.java
@@ -1,18 +1,14 @@
 package com.kllhy.roadmap.star.roadmap.application.command;
 
-import com.kllhy.roadmap.star.roadmap.domain.model.command.CreateStarRoadMapCommand;
-import com.kllhy.roadmap.star.roadmap.domain.model.command.UpdateStarRoadMapCommand;
 
 public interface StarRoadMapCommandService {
-    Long create(CreateStarRoadMapCommand command);
+    Long create(Long userId, Long roadmapId, int value);
 
-    void update(UpdateStarRoadMapCommand command);
+    void update(Long starRoadmapId, Long userId, int value);
 
-    void deleteById(Long starId);
+    void deleteByUserIdAndRoadmapId(Long userId, Long roadmapId);
 
     void deleteAllStarByUserId(Long userId);
 
     void deleteAllStarByRoadMapId(Long roadmapId);
-
-    void deleteByUserIdAndRoadmapId(Long userId, Long roadmapId);
 }

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandService.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandService.java
@@ -1,6 +1,5 @@
 package com.kllhy.roadmap.star.roadmap.application.command;
 
-
 public interface StarRoadMapCommandService {
     Long create(Long userId, Long roadmapId, int value);
 

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandServiceAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandServiceAdapter.java
@@ -42,7 +42,8 @@ public class StarRoadMapCommandServiceAdapter implements StarRoadMapCommandServi
 
     @Override
     public void update(Long starRoadmapId, Long userId, int value) {
-        UpdateStarRoadMapCommand command = new UpdateStarRoadMapCommand(userId, starRoadmapId, value);
+        UpdateStarRoadMapCommand command =
+                new UpdateStarRoadMapCommand(userId, starRoadmapId, value);
 
         StarRoadMap starRoadMap =
                 starRoadMapRepository

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandServiceAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandServiceAdapter.java
@@ -1,12 +1,20 @@
 package com.kllhy.roadmap.star.roadmap.application.command;
 
 import com.kllhy.roadmap.common.exception.DomainException;
+import com.kllhy.roadmap.roadmap.application.query.RoadMapQueryService;
+import com.kllhy.roadmap.roadmap.application.query.dto.RoadMapView;
 import com.kllhy.roadmap.star.roadmap.domain.exception.StarRoadMapErrorCode;
 import com.kllhy.roadmap.star.roadmap.domain.model.StarRoadMap;
 import com.kllhy.roadmap.star.roadmap.domain.model.command.CreateStarRoadMapCommand;
+import com.kllhy.roadmap.star.roadmap.domain.model.command.DeleteStarRoadMapCommand;
 import com.kllhy.roadmap.star.roadmap.domain.model.command.UpdateStarRoadMapCommand;
 import com.kllhy.roadmap.star.roadmap.domain.repository.StarRoadMapRepository;
 import com.kllhy.roadmap.star.roadmap.domain.service.StarRoadMapCreationService;
+import com.kllhy.roadmap.star.roadmap.domain.service.StarRoadMapDeletionService;
+import com.kllhy.roadmap.star.roadmap.domain.service.StarRoadMapUpdateService;
+import com.kllhy.roadmap.user.domain.enums.AccountStatus;
+import com.kllhy.roadmap.user.service.UserService;
+import com.kllhy.roadmap.user.service.view.UserView;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,36 +23,45 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class StarRoadMapCommandServiceAdapter implements StarRoadMapCommandService {
-    private final StarRoadMapRepository starRoadMapRepository;
+
+    private final UserService userService;
+    private final RoadMapQueryService roadMapQueryService;
     private final StarRoadMapCreationService starRoadMapCreationService;
+    private final StarRoadMapUpdateService starRoadMapUpdateService;
+    private final StarRoadMapDeletionService starRoadMapDeletionService;
+    private final StarRoadMapRepository starRoadMapRepository;
 
     @Override
-    public Long create(CreateStarRoadMapCommand command) {
+    public Long create(Long userId, Long roadmapId, int value) {
+        validateUserAndRoadMapStatus(userId, roadmapId);
+        CreateStarRoadMapCommand command = new CreateStarRoadMapCommand(userId, roadmapId, value);
         StarRoadMap starRoadMap = starRoadMapCreationService.create(command);
         StarRoadMap savedStarRoadMap = starRoadMapRepository.save(starRoadMap);
         return savedStarRoadMap.getId();
     }
 
     @Override
-    public void update(UpdateStarRoadMapCommand command) {
+    public void update(Long starRoadmapId, Long userId, int value) {
+        UpdateStarRoadMapCommand command = new UpdateStarRoadMapCommand(userId, starRoadmapId, value);
+
         StarRoadMap starRoadMap =
                 starRoadMapRepository
-                        .findById(command.starRoadMapId())
+                        .findById(starRoadmapId)
                         .orElseThrow(
                                 () ->
                                         new DomainException(
                                                 StarRoadMapErrorCode.STAR_ROAD_MAP_NOT_FOUND));
 
-        if (!starRoadMap.getUserId().equals(command.userId())) {
-            throw new DomainException(StarRoadMapErrorCode.STAR_ROAD_MAP_NOT_AUTHORIZED);
-        }
-
-        starRoadMap.update(command.value());
+        validateUserAndRoadMapStatus(userId, starRoadMap.getRoadMapId());
+        starRoadMapUpdateService.update(starRoadMap, command);
+        starRoadMapRepository.save(starRoadMap);
     }
 
     @Override
-    public void deleteById(Long starId) {
-        starRoadMapRepository.deleteById(starId);
+    public void deleteByUserIdAndRoadmapId(Long userId, Long roadmapId) {
+        validateUserAndRoadMapStatus(userId, roadmapId);
+        DeleteStarRoadMapCommand command = new DeleteStarRoadMapCommand(userId, roadmapId);
+        starRoadMapDeletionService.deleteByUserIdAndRoadmapId(command);
     }
 
     @Override
@@ -57,8 +74,15 @@ public class StarRoadMapCommandServiceAdapter implements StarRoadMapCommandServi
         starRoadMapRepository.deleteAllByRoadmapId(roadmapId);
     }
 
-    @Override
-    public void deleteByUserIdAndRoadmapId(Long userId, Long roadmapId) {
-        starRoadMapRepository.deleteByUserIdAndRoadmapId(userId, roadmapId);
+    private void validateUserAndRoadMapStatus(Long userId, Long roadmapId) {
+        UserView user = userService.getByUser(userId);
+        if (user.status() != AccountStatus.ACTIVE) {
+            throw new DomainException(StarRoadMapErrorCode.STAR_ROAD_MAP_USER_NOT_ACTIVE);
+        }
+
+        RoadMapView roadMap = roadMapQueryService.findById(roadmapId);
+        if (roadMap.isDraft() || roadMap.isDeleted()) {
+            throw new DomainException(StarRoadMapErrorCode.STAR_ROAD_MAP_ROADMAP_INVALID);
+        }
     }
 }

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/application/query/StarRoadMapQueryServiceAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/application/query/StarRoadMapQueryServiceAdapter.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -23,30 +22,22 @@ public class StarRoadMapQueryServiceAdapter implements StarRoadMapQueryService {
         return starRoadMapRepository
                 .findById(starRoadMapId)
                 .map(this::toView)
-                .orElseThrow(() -> new DomainException(StarRoadMapErrorCode.STAR_ROAD_MAP_NOT_FOUND));
+                .orElseThrow(
+                        () -> new DomainException(StarRoadMapErrorCode.STAR_ROAD_MAP_NOT_FOUND));
     }
 
     @Override
     public List<StarRoadMapView> getAllStarByUserId(Long userId) {
-        return starRoadMapRepository.findByUserId(userId)
-                .stream()
-                .map(this::toView)
-                .toList();
+        return starRoadMapRepository.findByUserId(userId).stream().map(this::toView).toList();
     }
 
     @Override
     public List<StarRoadMapView> getAllStarByRoadMapId(Long roadMapId) {
-        return starRoadMapRepository.findByRoadmapId(roadMapId)
-                .stream()
-                .map(this::toView)
-                .toList();
+        return starRoadMapRepository.findByRoadmapId(roadMapId).stream().map(this::toView).toList();
     }
 
     private StarRoadMapView toView(StarRoadMap starRoadMap) {
         return new StarRoadMapView(
-                starRoadMap.getUserId(),
-                starRoadMap.getRoadMapId(),
-                starRoadMap.getValue()
-        );
+                starRoadMap.getUserId(), starRoadMap.getRoadMapId(), starRoadMap.getValue());
     }
 }

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/application/query/StarRoadMapQueryServiceAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/application/query/StarRoadMapQueryServiceAdapter.java
@@ -1,0 +1,52 @@
+package com.kllhy.roadmap.star.roadmap.application.query;
+
+import com.kllhy.roadmap.common.exception.DomainException;
+import com.kllhy.roadmap.star.roadmap.application.query.dto.StarRoadMapView;
+import com.kllhy.roadmap.star.roadmap.domain.exception.StarRoadMapErrorCode;
+import com.kllhy.roadmap.star.roadmap.domain.model.StarRoadMap;
+import com.kllhy.roadmap.star.roadmap.domain.repository.StarRoadMapRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StarRoadMapQueryServiceAdapter implements StarRoadMapQueryService {
+
+    private final StarRoadMapRepository starRoadMapRepository;
+
+    @Override
+    public StarRoadMapView getById(Long starRoadMapId) {
+        return starRoadMapRepository
+                .findById(starRoadMapId)
+                .map(this::toView)
+                .orElseThrow(() -> new DomainException(StarRoadMapErrorCode.STAR_ROAD_MAP_NOT_FOUND));
+    }
+
+    @Override
+    public List<StarRoadMapView> getAllStarByUserId(Long userId) {
+        return starRoadMapRepository.findByUserId(userId)
+                .stream()
+                .map(this::toView)
+                .toList();
+    }
+
+    @Override
+    public List<StarRoadMapView> getAllStarByRoadMapId(Long roadMapId) {
+        return starRoadMapRepository.findByRoadmapId(roadMapId)
+                .stream()
+                .map(this::toView)
+                .toList();
+    }
+
+    private StarRoadMapView toView(StarRoadMap starRoadMap) {
+        return new StarRoadMapView(
+                starRoadMap.getUserId(),
+                starRoadMap.getRoadMapId(),
+                starRoadMap.getValue()
+        );
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/domain/model/command/DeleteStarRoadMapCommand.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/domain/model/command/DeleteStarRoadMapCommand.java
@@ -1,0 +1,3 @@
+package com.kllhy.roadmap.star.roadmap.domain.model.command;
+
+public record DeleteStarRoadMapCommand(Long userId, Long roadmapId) {}

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/domain/model/command/UpdateStarRoadMapCommand.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/domain/model/command/UpdateStarRoadMapCommand.java
@@ -2,9 +2,9 @@ package com.kllhy.roadmap.star.roadmap.domain.model.command;
 
 import java.util.Objects;
 
-public record UpdateStarRoadMapCommand(Long userId, Long starRoadMapId, int value) {
+public record UpdateStarRoadMapCommand(Long userId, Long starId, int newValue) {
     public UpdateStarRoadMapCommand {
-        Objects.requireNonNull(userId, "userId must not be null");
-        Objects.requireNonNull(starRoadMapId, "starRoadMapId must not be null");
+        Objects.requireNonNull(starId, "UpdateStarRoadMap: star_roadmapId is null");
+        Objects.requireNonNull(userId, "UpdateStarRoadMap: userId is null");
     }
 }

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/domain/repository/StarRoadMapRepository.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/domain/repository/StarRoadMapRepository.java
@@ -13,15 +13,13 @@ public interface StarRoadMapRepository {
 
     List<StarRoadMap> findByRoadmapId(Long roadmapId);
 
-    List<StarRoadMap> findAll();
+    Optional<StarRoadMap> findByUserIdAndRoadmapId(Long userId, Long roadmapId);
 
-    void deleteById(Long id);
+    void deleteByUserIdAndRoadmapId(Long userId, Long roadmapId);
 
     void deleteAllByUserId(Long userId);
 
     void deleteAllByRoadmapId(Long roadmapId);
-
-    void deleteByUserIdAndRoadmapId(Long userId, Long roadmapId);
 
     boolean existsByUserIdAndRoadmapId(Long userId, Long roadmapId);
 }

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/domain/service/StarRoadMapDeletionService.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/domain/service/StarRoadMapDeletionService.java
@@ -3,22 +3,22 @@ package com.kllhy.roadmap.star.roadmap.domain.service;
 import com.kllhy.roadmap.common.annotation.DomainService;
 import com.kllhy.roadmap.common.exception.DomainException;
 import com.kllhy.roadmap.star.roadmap.domain.exception.StarRoadMapErrorCode;
-import com.kllhy.roadmap.star.roadmap.domain.model.StarRoadMap;
-import com.kllhy.roadmap.star.roadmap.domain.model.command.CreateStarRoadMapCommand;
+import com.kllhy.roadmap.star.roadmap.domain.model.command.DeleteStarRoadMapCommand;
 import com.kllhy.roadmap.star.roadmap.domain.repository.StarRoadMapRepository;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
 @RequiredArgsConstructor
-public class StarRoadMapCreationService {
+public class StarRoadMapDeletionService {
 
     private final StarRoadMapRepository starRoadMapRepository;
 
-    public StarRoadMap create(CreateStarRoadMapCommand command) {
-        if (starRoadMapRepository.existsByUserIdAndRoadmapId(
+    public void deleteByUserIdAndRoadmapId(
+            DeleteStarRoadMapCommand command) {
+        if (!starRoadMapRepository.existsByUserIdAndRoadmapId(
                 command.userId(), command.roadmapId())) {
-            throw new DomainException(StarRoadMapErrorCode.STAR_ROAD_MAP_ALREADY_EXISTS);
+            throw new DomainException(StarRoadMapErrorCode.STAR_ROAD_MAP_NOT_FOUND);
         }
-        return StarRoadMap.create(command);
+        starRoadMapRepository.deleteByUserIdAndRoadmapId(command.userId(), command.roadmapId());
     }
 }

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/domain/service/StarRoadMapDeletionService.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/domain/service/StarRoadMapDeletionService.java
@@ -13,8 +13,7 @@ public class StarRoadMapDeletionService {
 
     private final StarRoadMapRepository starRoadMapRepository;
 
-    public void deleteByUserIdAndRoadmapId(
-            DeleteStarRoadMapCommand command) {
+    public void deleteByUserIdAndRoadmapId(DeleteStarRoadMapCommand command) {
         if (!starRoadMapRepository.existsByUserIdAndRoadmapId(
                 command.userId(), command.roadmapId())) {
             throw new DomainException(StarRoadMapErrorCode.STAR_ROAD_MAP_NOT_FOUND);

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/domain/service/StarRoadMapUpdateService.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/domain/service/StarRoadMapUpdateService.java
@@ -1,0 +1,20 @@
+package com.kllhy.roadmap.star.roadmap.domain.service;
+
+import com.kllhy.roadmap.common.annotation.DomainService;
+import com.kllhy.roadmap.common.exception.DomainException;
+import com.kllhy.roadmap.star.roadmap.domain.exception.StarRoadMapErrorCode;
+import com.kllhy.roadmap.star.roadmap.domain.model.StarRoadMap;
+import com.kllhy.roadmap.star.roadmap.domain.model.command.UpdateStarRoadMapCommand;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class StarRoadMapUpdateService {
+
+    public void update(StarRoadMap star, UpdateStarRoadMapCommand command) {
+        if (!star.getUserId().equals(command.userId())) {
+            throw new DomainException(StarRoadMapErrorCode.STAR_ROAD_MAP_NOT_AUTHORIZED);
+        }
+        star.update(command.newValue());
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/infrastructure/StarRoadMapRepositoryAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/infrastructure/StarRoadMapRepositoryAdapter.java
@@ -35,13 +35,13 @@ public class StarRoadMapRepositoryAdapter implements StarRoadMapRepository {
     }
 
     @Override
-    public List<StarRoadMap> findAll() {
-        return starRoadMapJpaRepository.findAll();
+    public Optional<StarRoadMap> findByUserIdAndRoadmapId(Long userId, Long roadmapId) {
+        return starRoadMapJpaRepository.findByUserIdAndRoadMapId(userId, roadmapId);
     }
 
     @Override
-    public void deleteById(Long id) {
-        starRoadMapJpaRepository.deleteById(id);
+    public void deleteByUserIdAndRoadmapId(Long userId, Long roadmapId) {
+        starRoadMapJpaRepository.deleteByUserIdAndRoadMapId(userId, roadmapId);
     }
 
     @Override
@@ -57,10 +57,5 @@ public class StarRoadMapRepositoryAdapter implements StarRoadMapRepository {
     @Override
     public boolean existsByUserIdAndRoadmapId(Long userId, Long roadmapId) {
         return starRoadMapJpaRepository.existsByUserIdAndRoadMapId(userId, roadmapId);
-    }
-
-    @Override
-    public void deleteByUserIdAndRoadmapId(Long userId, Long roadmapId) {
-        starRoadMapJpaRepository.deleteByUserIdAndRoadMapId(userId, roadmapId);
     }
 }

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/infrastructure/jpa/StarRoadMapJpaRepository.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/infrastructure/jpa/StarRoadMapJpaRepository.java
@@ -2,6 +2,7 @@ package com.kllhy.roadmap.star.roadmap.infrastructure.jpa;
 
 import com.kllhy.roadmap.star.roadmap.domain.model.StarRoadMap;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StarRoadMapJpaRepository extends JpaRepository<StarRoadMap, Long> {
@@ -10,11 +11,13 @@ public interface StarRoadMapJpaRepository extends JpaRepository<StarRoadMap, Lon
 
     List<StarRoadMap> findStarRoadMapByRoadMapId(Long roadmapId);
 
+    Optional<StarRoadMap> findByUserIdAndRoadMapId(Long userId, Long roadMapId);
+
+    void deleteByUserIdAndRoadMapId(Long userId, Long roadmapId);
+
     void deleteStarRoadMapsByUserId(Long userId);
 
     void deleteStarRoadMapsByRoadMapId(Long roadmapId);
-
-    void deleteByUserIdAndRoadMapId(Long userId, Long roadmapId);
 
     boolean existsByUserIdAndRoadMapId(Long userId, Long roadmapId);
 }

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
@@ -7,6 +7,7 @@ import com.kllhy.roadmap.star.roadmap.presentation.exception.ErrorResponse;
 import com.kllhy.roadmap.star.roadmap.presentation.request.CreateStarRoadMapRequest;
 import com.kllhy.roadmap.star.roadmap.presentation.request.DeleteStarRoadMapRequest;
 import com.kllhy.roadmap.star.roadmap.presentation.request.UpdateStarRoadMapRequest;
+import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,7 +31,7 @@ public class StarRoadMapController {
     private final StarRoadMapQueryService starRoadMapQueryService;
 
     @PostMapping
-    public ResponseEntity<Void> createStarRoadMap(@RequestBody CreateStarRoadMapRequest request) {
+    public ResponseEntity<Void> createStarRoadMap(@RequestBody @Valid CreateStarRoadMapRequest request) {
         Long starRoadMapId =
                 starRoadMapCommandService.create(
                         request.userId(), request.roadmapId(), request.value());
@@ -64,14 +65,14 @@ public class StarRoadMapController {
 
     @PutMapping("/{id}")
     public ResponseEntity<Void> updateStarRoadMap(
-            @PathVariable Long id, @RequestBody UpdateStarRoadMapRequest request) {
+            @PathVariable Long id, @RequestBody @Valid UpdateStarRoadMapRequest request) {
         starRoadMapCommandService.update(id, request.userId(), request.value());
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping
     public ResponseEntity<Void> deleteStarRoadMapByUserAndRoadmap(
-            @RequestBody DeleteStarRoadMapRequest request) {
+            @RequestBody @Valid DeleteStarRoadMapRequest request) {
         starRoadMapCommandService.deleteByUserIdAndRoadmapId(request.userId(), request.roadmapId());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
@@ -46,8 +46,7 @@ public class StarRoadMapController {
     @GetMapping
     public ResponseEntity<?> getStarRoadMaps(
             @RequestParam(required = false) Long userId,
-            @RequestParam(required = false) Long roadmapId
-    ) {
+            @RequestParam(required = false) Long roadmapId) {
         if (userId != null) {
             var starRoadMapViews = starRoadMapQueryService.getAllStarByUserId(userId);
             return ResponseEntity.ok(starRoadMapViews);
@@ -57,10 +56,11 @@ public class StarRoadMapController {
             return ResponseEntity.ok(starRoadMapViews);
         }
 
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST, "Either userId or roadmapId must be provided.");
+        ErrorResponse errorResponse =
+                new ErrorResponse(
+                        HttpStatus.BAD_REQUEST, "Either userId or roadmapId must be provided.");
         return ResponseEntity.badRequest().body(errorResponse);
     }
-
 
     @PutMapping("/{id}")
     public ResponseEntity<Void> updateStarRoadMap(

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
@@ -1,9 +1,8 @@
 package com.kllhy.roadmap.star.roadmap.presentation;
 
 import com.kllhy.roadmap.star.roadmap.application.command.StarRoadMapCommandService;
-import com.kllhy.roadmap.star.roadmap.domain.model.command.CreateStarRoadMapCommand;
-import com.kllhy.roadmap.star.roadmap.domain.model.command.UpdateStarRoadMapCommand;
 import com.kllhy.roadmap.star.roadmap.presentation.request.CreateStarRoadMapRequest;
+import com.kllhy.roadmap.star.roadmap.presentation.request.DeleteStarRoadMapRequest;
 import com.kllhy.roadmap.star.roadmap.presentation.request.UpdateStarRoadMapRequest;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,32 +24,24 @@ public class StarRoadMapController {
 
     @PostMapping
     public ResponseEntity<Void> createStarRoadMap(@RequestBody CreateStarRoadMapRequest request) {
-        CreateStarRoadMapCommand command =
-                new CreateStarRoadMapCommand(
+        Long starRoadMapId =
+                starRoadMapCommandService.create(
                         request.userId(), request.roadmapId(), request.value());
-        Long starRoadMapId = starRoadMapCommandService.create(command);
         return ResponseEntity.created(URI.create("/api-v1/star-roadmaps/" + starRoadMapId)).build();
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<Void> updateStarRoadMap(
             @PathVariable Long id, @RequestBody UpdateStarRoadMapRequest request) {
-        UpdateStarRoadMapCommand command =
-                new UpdateStarRoadMapCommand(request.userId(), id, request.value());
-        starRoadMapCommandService.update(command);
+        starRoadMapCommandService.update(id, request.userId(), request.value());
         return ResponseEntity.ok().build();
-    }
-
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteStarRoadMap(@PathVariable Long id) {
-        starRoadMapCommandService.deleteById(id);
-        return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping
     public ResponseEntity<Void> deleteStarRoadMapByUserAndRoadmap(
-            @RequestParam Long userId, @RequestParam Long roadmapId) {
-        starRoadMapCommandService.deleteByUserIdAndRoadmapId(userId, roadmapId);
+            @RequestBody DeleteStarRoadMapRequest request) {
+        starRoadMapCommandService.deleteByUserIdAndRoadmapId(
+                request.userId(), request.roadmapId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
@@ -1,18 +1,24 @@
 package com.kllhy.roadmap.star.roadmap.presentation;
 
 import com.kllhy.roadmap.star.roadmap.application.command.StarRoadMapCommandService;
+import com.kllhy.roadmap.star.roadmap.application.query.StarRoadMapQueryService;
+import com.kllhy.roadmap.star.roadmap.application.query.dto.StarRoadMapView;
+import com.kllhy.roadmap.star.roadmap.presentation.exception.ErrorResponse;
 import com.kllhy.roadmap.star.roadmap.presentation.request.CreateStarRoadMapRequest;
 import com.kllhy.roadmap.star.roadmap.presentation.request.DeleteStarRoadMapRequest;
 import com.kllhy.roadmap.star.roadmap.presentation.request.UpdateStarRoadMapRequest;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class StarRoadMapController {
 
     private final StarRoadMapCommandService starRoadMapCommandService;
+    private final StarRoadMapQueryService starRoadMapQueryService;
 
     @PostMapping
     public ResponseEntity<Void> createStarRoadMap(@RequestBody CreateStarRoadMapRequest request) {
@@ -29,6 +36,31 @@ public class StarRoadMapController {
                         request.userId(), request.roadmapId(), request.value());
         return ResponseEntity.created(URI.create("/api-v1/star-roadmaps/" + starRoadMapId)).build();
     }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<StarRoadMapView> getStarRoadMapById(@PathVariable Long id) {
+        var starRoadMapView = starRoadMapQueryService.getById(id);
+        return ResponseEntity.ok(starRoadMapView);
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getStarRoadMaps(
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Long roadmapId
+    ) {
+        if (userId != null) {
+            var starRoadMapViews = starRoadMapQueryService.getAllStarByUserId(userId);
+            return ResponseEntity.ok(starRoadMapViews);
+        }
+        if (roadmapId != null) {
+            var starRoadMapViews = starRoadMapQueryService.getAllStarByRoadMapId(roadmapId);
+            return ResponseEntity.ok(starRoadMapViews);
+        }
+
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST, "Either userId or roadmapId must be provided.");
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
 
     @PutMapping("/{id}")
     public ResponseEntity<Void> updateStarRoadMap(

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
@@ -40,8 +40,7 @@ public class StarRoadMapController {
     @DeleteMapping
     public ResponseEntity<Void> deleteStarRoadMapByUserAndRoadmap(
             @RequestBody DeleteStarRoadMapRequest request) {
-        starRoadMapCommandService.deleteByUserIdAndRoadmapId(
-                request.userId(), request.roadmapId());
+        starRoadMapCommandService.deleteByUserIdAndRoadmapId(request.userId(), request.roadmapId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/StarRoadMapController.java
@@ -31,7 +31,8 @@ public class StarRoadMapController {
     private final StarRoadMapQueryService starRoadMapQueryService;
 
     @PostMapping
-    public ResponseEntity<Void> createStarRoadMap(@RequestBody @Valid CreateStarRoadMapRequest request) {
+    public ResponseEntity<Void> createStarRoadMap(
+            @RequestBody @Valid CreateStarRoadMapRequest request) {
         Long starRoadMapId =
                 starRoadMapCommandService.create(
                         request.userId(), request.roadmapId(), request.value());

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/exception/ErrorResponse.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/exception/ErrorResponse.java
@@ -1,0 +1,5 @@
+package com.kllhy.roadmap.star.roadmap.presentation.exception;
+
+import org.springframework.http.HttpStatus;
+
+public record ErrorResponse(HttpStatus code, String message) {}

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/CreateStarRoadMapRequest.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/CreateStarRoadMapRequest.java
@@ -1,3 +1,11 @@
 package com.kllhy.roadmap.star.roadmap.presentation.request;
 
-public record CreateStarRoadMapRequest(Long userId, Long roadmapId, int value) {}
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record CreateStarRoadMapRequest(
+        @NotNull Long userId,
+        @NotNull Long roadmapId,
+        @NotNull @PositiveOrZero int value
+) {
+}

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/CreateStarRoadMapRequest.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/CreateStarRoadMapRequest.java
@@ -4,8 +4,4 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
 public record CreateStarRoadMapRequest(
-        @NotNull Long userId,
-        @NotNull Long roadmapId,
-        @NotNull @PositiveOrZero int value
-) {
-}
+        @NotNull Long userId, @NotNull Long roadmapId, @NotNull @PositiveOrZero int value) {}

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/DeleteStarRoadMapRequest.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/DeleteStarRoadMapRequest.java
@@ -1,3 +1,6 @@
 package com.kllhy.roadmap.star.roadmap.presentation.request;
 
-public record DeleteStarRoadMapRequest(Long userId, Long roadmapId) {}
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteStarRoadMapRequest(@NotNull Long userId, @NotNull Long roadmapId) {
+}

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/DeleteStarRoadMapRequest.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/DeleteStarRoadMapRequest.java
@@ -1,0 +1,3 @@
+package com.kllhy.roadmap.star.roadmap.presentation.request;
+
+public record DeleteStarRoadMapRequest(Long userId, Long roadmapId) {}

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/DeleteStarRoadMapRequest.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/DeleteStarRoadMapRequest.java
@@ -2,5 +2,4 @@ package com.kllhy.roadmap.star.roadmap.presentation.request;
 
 import jakarta.validation.constraints.NotNull;
 
-public record DeleteStarRoadMapRequest(@NotNull Long userId, @NotNull Long roadmapId) {
-}
+public record DeleteStarRoadMapRequest(@NotNull Long userId, @NotNull Long roadmapId) {}

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/UpdateStarRoadMapRequest.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/UpdateStarRoadMapRequest.java
@@ -1,3 +1,10 @@
 package com.kllhy.roadmap.star.roadmap.presentation.request;
 
-public record UpdateStarRoadMapRequest(Long userId, int value) {}
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record UpdateStarRoadMapRequest(
+        @NotNull Long userId,
+        @NotNull @PositiveOrZero int value
+) {
+}

--- a/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/UpdateStarRoadMapRequest.java
+++ b/src/main/java/com/kllhy/roadmap/star/roadmap/presentation/request/UpdateStarRoadMapRequest.java
@@ -3,8 +3,4 @@ package com.kllhy.roadmap.star.roadmap.presentation.request;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
-public record UpdateStarRoadMapRequest(
-        @NotNull Long userId,
-        @NotNull @PositiveOrZero int value
-) {
-}
+public record UpdateStarRoadMapRequest(@NotNull Long userId, @NotNull @PositiveOrZero int value) {}

--- a/src/test/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandServiceAdapterTest.java
+++ b/src/test/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandServiceAdapterTest.java
@@ -40,23 +40,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class StarRoadMapCommandServiceAdapterTest {
 
-    @InjectMocks
-    private StarRoadMapCommandServiceAdapter starRoadMapCommandServiceAdapter;
+    @InjectMocks private StarRoadMapCommandServiceAdapter starRoadMapCommandServiceAdapter;
 
-    @Mock
-    private StarRoadMapRepository starRoadMapRepository;
-    @Mock
-    private StarRoadMapCreationService starRoadMapCreationService;
-    @Mock
-    private StarRoadMapUpdateService starRoadMapUpdateService;
-    @Mock
-    private StarRoadMapDeletionService starRoadMapDeletionService;
-    @Mock
-    private UserService userService;
-    @Mock
-    private RoadMapQueryService roadMapQueryService;
-    @Mock
-    private User mockUser;
+    @Mock private StarRoadMapRepository starRoadMapRepository;
+    @Mock private StarRoadMapCreationService starRoadMapCreationService;
+    @Mock private StarRoadMapUpdateService starRoadMapUpdateService;
+    @Mock private StarRoadMapDeletionService starRoadMapDeletionService;
+    @Mock private UserService userService;
+    @Mock private RoadMapQueryService roadMapQueryService;
+    @Mock private User mockUser;
 
     private UserView mockUserView;
     private RoadMapView mockRoadMapView;
@@ -72,7 +64,16 @@ class StarRoadMapCommandServiceAdapterTest {
         Timestamp now = Timestamp.from(Instant.now());
         mockRoadMapView =
                 new RoadMapView(
-                        1L, "title", "desc", null, now, now, false, false, 1L, List.of(mock(TopicView.class)));
+                        1L,
+                        "title",
+                        "desc",
+                        null,
+                        now,
+                        now,
+                        false,
+                        false,
+                        1L,
+                        List.of(mock(TopicView.class)));
     }
 
     @Test
@@ -113,11 +114,14 @@ class StarRoadMapCommandServiceAdapterTest {
 
         StarRoadMap mockStarRoadMap = mock(StarRoadMap.class);
 
-        when(starRoadMapRepository.findById(starRoadmapId)).thenReturn(Optional.of(mockStarRoadMap));
+        when(starRoadMapRepository.findById(starRoadmapId))
+                .thenReturn(Optional.of(mockStarRoadMap));
         when(mockStarRoadMap.getRoadMapId()).thenReturn(roadmapId);
         when(userService.getByUser(userId)).thenReturn(mockUserView);
         when(roadMapQueryService.findById(roadmapId)).thenReturn(mockRoadMapView);
-        doNothing().when(starRoadMapUpdateService).update(any(StarRoadMap.class), any(UpdateStarRoadMapCommand.class));
+        doNothing()
+                .when(starRoadMapUpdateService)
+                .update(any(StarRoadMap.class), any(UpdateStarRoadMapCommand.class));
         when(starRoadMapRepository.save(mockStarRoadMap)).thenReturn(mockStarRoadMap);
 
         // when
@@ -125,7 +129,8 @@ class StarRoadMapCommandServiceAdapterTest {
 
         // then
         verify(starRoadMapRepository, times(1)).findById(starRoadmapId);
-        verify(starRoadMapUpdateService, times(1)).update(any(StarRoadMap.class), any(UpdateStarRoadMapCommand.class));
+        verify(starRoadMapUpdateService, times(1))
+                .update(any(StarRoadMap.class), any(UpdateStarRoadMapCommand.class));
         verify(starRoadMapRepository, times(1)).save(mockStarRoadMap);
     }
 

--- a/src/test/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandServiceAdapterTest.java
+++ b/src/test/java/com/kllhy/roadmap/star/roadmap/application/command/StarRoadMapCommandServiceAdapterTest.java
@@ -2,22 +2,34 @@ package com.kllhy.roadmap.star.roadmap.application.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.anyInt;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.kllhy.roadmap.common.exception.DomainException;
-import com.kllhy.roadmap.star.roadmap.domain.exception.StarRoadMapErrorCode;
+import com.kllhy.roadmap.roadmap.application.query.RoadMapQueryService;
+import com.kllhy.roadmap.roadmap.application.query.dto.RoadMapView;
+import com.kllhy.roadmap.roadmap.application.query.dto.TopicView;
 import com.kllhy.roadmap.star.roadmap.domain.model.StarRoadMap;
 import com.kllhy.roadmap.star.roadmap.domain.model.command.CreateStarRoadMapCommand;
+import com.kllhy.roadmap.star.roadmap.domain.model.command.DeleteStarRoadMapCommand;
 import com.kllhy.roadmap.star.roadmap.domain.model.command.UpdateStarRoadMapCommand;
 import com.kllhy.roadmap.star.roadmap.domain.repository.StarRoadMapRepository;
 import com.kllhy.roadmap.star.roadmap.domain.service.StarRoadMapCreationService;
+import com.kllhy.roadmap.star.roadmap.domain.service.StarRoadMapDeletionService;
+import com.kllhy.roadmap.star.roadmap.domain.service.StarRoadMapUpdateService;
+import com.kllhy.roadmap.user.domain.User;
+import com.kllhy.roadmap.user.domain.enums.AccountStatus;
+import com.kllhy.roadmap.user.service.UserService;
+import com.kllhy.roadmap.user.service.view.UserView;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,30 +40,65 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class StarRoadMapCommandServiceAdapterTest {
 
-    @InjectMocks private StarRoadMapCommandServiceAdapter starRoadMapCommandServiceAdapter;
+    @InjectMocks
+    private StarRoadMapCommandServiceAdapter starRoadMapCommandServiceAdapter;
 
-    @Mock private StarRoadMapRepository starRoadMapRepository;
+    @Mock
+    private StarRoadMapRepository starRoadMapRepository;
+    @Mock
+    private StarRoadMapCreationService starRoadMapCreationService;
+    @Mock
+    private StarRoadMapUpdateService starRoadMapUpdateService;
+    @Mock
+    private StarRoadMapDeletionService starRoadMapDeletionService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private RoadMapQueryService roadMapQueryService;
+    @Mock
+    private User mockUser;
 
-    @Mock private StarRoadMapCreationService starRoadMapCreationService;
+    private UserView mockUserView;
+    private RoadMapView mockRoadMapView;
+
+    @BeforeEach
+    void setUp() {
+        when(mockUser.getId()).thenReturn(1L);
+        when(mockUser.getEmail()).thenReturn("testUser@example.com");
+        when(mockUser.getStatus()).thenReturn(AccountStatus.ACTIVE);
+        when(mockUser.getLeftAt()).thenReturn(null);
+        mockUserView = UserView.of(mockUser);
+
+        Timestamp now = Timestamp.from(Instant.now());
+        mockRoadMapView =
+                new RoadMapView(
+                        1L, "title", "desc", null, now, now, false, false, 1L, List.of(mock(TopicView.class)));
+    }
 
     @Test
     @DisplayName("생성 메서드 호출 시 로직을 정상적으로 오케스트레이션한다.")
     void shouldOrchestrateCreation_whenCreateIsCalled() {
         // given
-        CreateStarRoadMapCommand command = new CreateStarRoadMapCommand(1L, 1L, 5);
+        Long userId = 1L;
+        Long roadmapId = 1L;
+        int value = 5;
+
         StarRoadMap mockStarRoadMap = mock(StarRoadMap.class);
         StarRoadMap savedMockStarRoadMap = mock(StarRoadMap.class);
 
-        when(starRoadMapCreationService.create(command)).thenReturn(mockStarRoadMap);
+        when(userService.getByUser(userId)).thenReturn(mockUserView);
+        when(roadMapQueryService.findById(roadmapId)).thenReturn(mockRoadMapView);
+        when(starRoadMapCreationService.create(any(CreateStarRoadMapCommand.class)))
+                .thenReturn(mockStarRoadMap);
         when(starRoadMapRepository.save(mockStarRoadMap)).thenReturn(savedMockStarRoadMap);
         when(savedMockStarRoadMap.getId()).thenReturn(99L);
 
         // when
-        Long resultId = starRoadMapCommandServiceAdapter.create(command);
+        Long resultId = starRoadMapCommandServiceAdapter.create(userId, roadmapId, value);
 
         // then
         assertEquals(99L, resultId);
-        verify(starRoadMapCreationService, times(1)).create(command);
+        verify(starRoadMapCreationService, times(1)).create(any(CreateStarRoadMapCommand.class));
         verify(starRoadMapRepository, times(1)).save(mockStarRoadMap);
     }
 
@@ -59,52 +106,65 @@ class StarRoadMapCommandServiceAdapterTest {
     @DisplayName("수정 메서드 호출 시 로직을 정상적으로 오케스트레이션한다.")
     void shouldOrchestrateUpdate_whenUpdateIsCalled() {
         // given
-        UpdateStarRoadMapCommand command = new UpdateStarRoadMapCommand(1L, 99L, 4);
+        Long userId = 1L;
+        Long starRoadmapId = 99L;
+        int value = 4;
+        Long roadmapId = 1L;
+
         StarRoadMap mockStarRoadMap = mock(StarRoadMap.class);
 
-        when(starRoadMapRepository.findById(command.starRoadMapId()))
-                .thenReturn(Optional.of(mockStarRoadMap));
-        when(mockStarRoadMap.getUserId()).thenReturn(command.userId());
+        when(starRoadMapRepository.findById(starRoadmapId)).thenReturn(Optional.of(mockStarRoadMap));
+        when(mockStarRoadMap.getRoadMapId()).thenReturn(roadmapId);
+        when(userService.getByUser(userId)).thenReturn(mockUserView);
+        when(roadMapQueryService.findById(roadmapId)).thenReturn(mockRoadMapView);
+        doNothing().when(starRoadMapUpdateService).update(any(StarRoadMap.class), any(UpdateStarRoadMapCommand.class));
+        when(starRoadMapRepository.save(mockStarRoadMap)).thenReturn(mockStarRoadMap);
 
         // when
-        starRoadMapCommandServiceAdapter.update(command);
+        starRoadMapCommandServiceAdapter.update(starRoadmapId, userId, value);
 
         // then
-        verify(mockStarRoadMap, times(1)).update(command.value());
+        verify(starRoadMapRepository, times(1)).findById(starRoadmapId);
+        verify(starRoadMapUpdateService, times(1)).update(any(StarRoadMap.class), any(UpdateStarRoadMapCommand.class));
+        verify(starRoadMapRepository, times(1)).save(mockStarRoadMap);
     }
 
     @Test
-    @DisplayName("소유자가 아닌 사용자가 수정 메서드 호출 시 예외가 발생한다.")
-    void shouldThrowException_whenUpdateByNonOwner() {
+    @DisplayName("수정 메서드 호출 시 별점이 존재하지 않으면 예외가 발생한다.")
+    void shouldThrowException_whenUpdateWithNonExistentStar() {
         // given
-        UpdateStarRoadMapCommand command = new UpdateStarRoadMapCommand(1L, 99L, 4);
-        StarRoadMap mockStarRoadMap = mock(StarRoadMap.class);
+        Long userId = 1L;
+        Long starRoadmapId = 99L;
+        int value = 4;
 
-        when(starRoadMapRepository.findById(command.starRoadMapId()))
-                .thenReturn(Optional.of(mockStarRoadMap));
-        when(mockStarRoadMap.getUserId()).thenReturn(2L);
+        when(starRoadMapRepository.findById(starRoadmapId)).thenReturn(Optional.empty());
 
         // when & then
-        DomainException exception =
-                assertThrows(
-                        DomainException.class,
-                        () -> starRoadMapCommandServiceAdapter.update(command));
-        assertEquals(StarRoadMapErrorCode.STAR_ROAD_MAP_NOT_AUTHORIZED, exception.getErrorCode());
-        verify(mockStarRoadMap, never()).update(anyInt());
+        assertThrows(
+                DomainException.class,
+                () -> starRoadMapCommandServiceAdapter.update(starRoadmapId, userId, value));
+        verify(starRoadMapUpdateService, times(0)).update(any(), any());
     }
 
     @Test
-    @DisplayName("별점 아이디로 삭제 메서드 호출 시 리포지토리에 정상적으로 위임한다.")
-    void shouldDelegateDeleteById_whenDeleteByIdIsCalled() {
+    @DisplayName("삭제 메서드 호출 시 로직을 정상적으로 오케스트레이션한다.")
+    void shouldOrchestrateDeletion_whenDeleteIsCalled() {
         // given
-        Long starId = 99L;
-        doNothing().when(starRoadMapRepository).deleteById(starId);
+        Long userId = 1L;
+        Long roadmapId = 1L;
+
+        when(userService.getByUser(userId)).thenReturn(mockUserView);
+        when(roadMapQueryService.findById(roadmapId)).thenReturn(mockRoadMapView);
+        doNothing()
+                .when(starRoadMapDeletionService)
+                .deleteByUserIdAndRoadmapId(any(DeleteStarRoadMapCommand.class));
 
         // when
-        starRoadMapCommandServiceAdapter.deleteById(starId);
+        starRoadMapCommandServiceAdapter.deleteByUserIdAndRoadmapId(userId, roadmapId);
 
         // then
-        verify(starRoadMapRepository, times(1)).deleteById(starId);
+        verify(starRoadMapDeletionService, times(1))
+                .deleteByUserIdAndRoadmapId(any(DeleteStarRoadMapCommand.class));
     }
 
     @Test
@@ -133,20 +193,5 @@ class StarRoadMapCommandServiceAdapterTest {
 
         // then
         verify(starRoadMapRepository, times(1)).deleteAllByRoadmapId(roadmapId);
-    }
-
-    @Test
-    @DisplayName("유저 아이디와 로드맵에 해당하는 별점 삭제 메서드 호출 시 리포지토리에 정상적으로 위임한다.")
-    void shouldDelegateDeleteByUserIdAndRoadmapId_whenDeleteByUserIdAndRoadmapIdIsCalled() {
-        // given
-        Long userId = 1L;
-        Long roadmapId = 1L;
-        doNothing().when(starRoadMapRepository).deleteByUserIdAndRoadmapId(userId, roadmapId);
-
-        // when
-        starRoadMapCommandServiceAdapter.deleteByUserIdAndRoadmapId(userId, roadmapId);
-
-        // then
-        verify(starRoadMapRepository, times(1)).deleteByUserIdAndRoadmapId(userId, roadmapId);
     }
 }

--- a/src/test/java/com/kllhy/roadmap/star/roadmap/application/query/StarRoadMapQueryServiceAdapterTest.java
+++ b/src/test/java/com/kllhy/roadmap/star/roadmap/application/query/StarRoadMapQueryServiceAdapterTest.java
@@ -23,11 +23,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class StarRoadMapQueryServiceAdapterTest {
 
-    @InjectMocks
-    private StarRoadMapQueryServiceAdapter starRoadMapQueryServiceAdapter;
+    @InjectMocks private StarRoadMapQueryServiceAdapter starRoadMapQueryServiceAdapter;
 
-    @Mock
-    private StarRoadMapRepository starRoadMapRepository;
+    @Mock private StarRoadMapRepository starRoadMapRepository;
 
     @Test
     @DisplayName("ID로 별점 조회 시, 존재하는 경우 StarRoadMapView를 반환한다.")
@@ -48,8 +46,7 @@ class StarRoadMapQueryServiceAdapterTest {
         assertAll(
                 () -> assertEquals(10L, result.userId()),
                 () -> assertEquals(100L, result.roadMapId()),
-                () -> assertEquals(5, result.value())
-        );
+                () -> assertEquals(5, result.value()));
     }
 
     @Test
@@ -60,10 +57,10 @@ class StarRoadMapQueryServiceAdapterTest {
         when(starRoadMapRepository.findById(starId)).thenReturn(Optional.empty());
 
         // when & then
-        DomainException exception = assertThrows(
-                DomainException.class,
-                () -> starRoadMapQueryServiceAdapter.getById(starId)
-        );
+        DomainException exception =
+                assertThrows(
+                        DomainException.class,
+                        () -> starRoadMapQueryServiceAdapter.getById(starId));
         assertEquals(StarRoadMapErrorCode.STAR_ROAD_MAP_NOT_FOUND, exception.getErrorCode());
     }
 

--- a/src/test/java/com/kllhy/roadmap/star/roadmap/application/query/StarRoadMapQueryServiceAdapterTest.java
+++ b/src/test/java/com/kllhy/roadmap/star/roadmap/application/query/StarRoadMapQueryServiceAdapterTest.java
@@ -1,0 +1,131 @@
+package com.kllhy.roadmap.star.roadmap.application.query;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.kllhy.roadmap.common.exception.DomainException;
+import com.kllhy.roadmap.star.roadmap.domain.exception.StarRoadMapErrorCode;
+import com.kllhy.roadmap.star.roadmap.domain.model.StarRoadMap;
+import com.kllhy.roadmap.star.roadmap.domain.repository.StarRoadMapRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StarRoadMapQueryServiceAdapterTest {
+
+    @InjectMocks
+    private StarRoadMapQueryServiceAdapter starRoadMapQueryServiceAdapter;
+
+    @Mock
+    private StarRoadMapRepository starRoadMapRepository;
+
+    @Test
+    @DisplayName("ID로 별점 조회 시, 존재하는 경우 StarRoadMapView를 반환한다.")
+    void shouldReturnView_whenGetByIdIsCalledWithExistingId() {
+        // given
+        Long starId = 1L;
+        StarRoadMap mockStarRoadMap = mock(StarRoadMap.class);
+        when(mockStarRoadMap.getUserId()).thenReturn(10L);
+        when(mockStarRoadMap.getRoadMapId()).thenReturn(100L);
+        when(mockStarRoadMap.getValue()).thenReturn(5);
+
+        when(starRoadMapRepository.findById(starId)).thenReturn(Optional.of(mockStarRoadMap));
+
+        // when
+        var result = starRoadMapQueryServiceAdapter.getById(starId);
+
+        // then
+        assertAll(
+                () -> assertEquals(10L, result.userId()),
+                () -> assertEquals(100L, result.roadMapId()),
+                () -> assertEquals(5, result.value())
+        );
+    }
+
+    @Test
+    @DisplayName("ID로 별점 조회 시, 존재하지 않는 경우 예외를 발생시킨다.")
+    void shouldThrowException_whenGetByIdIsCalledWithNonExistingId() {
+        // given
+        Long starId = 1L;
+        when(starRoadMapRepository.findById(starId)).thenReturn(Optional.empty());
+
+        // when & then
+        DomainException exception = assertThrows(
+                DomainException.class,
+                () -> starRoadMapQueryServiceAdapter.getById(starId)
+        );
+        assertEquals(StarRoadMapErrorCode.STAR_ROAD_MAP_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("유저 ID로 모든 별점 조회 시, 결과를 StarRoadMapView 리스트로 반환한다.")
+    void shouldReturnViewList_whenGetAllByUserIdIsCalled() {
+        // given
+        Long userId = 10L;
+        StarRoadMap mockStarRoadMap1 = mock(StarRoadMap.class);
+        StarRoadMap mockStarRoadMap2 = mock(StarRoadMap.class);
+        when(starRoadMapRepository.findByUserId(userId))
+                .thenReturn(List.of(mockStarRoadMap1, mockStarRoadMap2));
+
+        // when
+        var results = starRoadMapQueryServiceAdapter.getAllStarByUserId(userId);
+
+        // then
+        assertEquals(2, results.size());
+    }
+
+    @Test
+    @DisplayName("유저 ID로 모든 별점 조회 시, 결과가 없으면 빈 리스트를 반환한다.")
+    void shouldReturnEmptyList_whenGetAllByUserIdIsCalledWithNoResults() {
+        // given
+        Long userId = 10L;
+        when(starRoadMapRepository.findByUserId(userId)).thenReturn(List.of());
+
+        // when
+        var results = starRoadMapQueryServiceAdapter.getAllStarByUserId(userId);
+
+        // then
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    @DisplayName("로드맵 ID로 모든 별점 조회 시, 결과를 StarRoadMapView 리스트로 반환한다.")
+    void shouldReturnViewList_whenGetAllByRoadmapIdIsCalled() {
+        // given
+        Long roadmapId = 100L;
+        StarRoadMap mockStarRoadMap1 = mock(StarRoadMap.class);
+        StarRoadMap mockStarRoadMap2 = mock(StarRoadMap.class);
+        when(starRoadMapRepository.findByRoadmapId(roadmapId))
+                .thenReturn(List.of(mockStarRoadMap1, mockStarRoadMap2));
+
+        // when
+        var results = starRoadMapQueryServiceAdapter.getAllStarByRoadMapId(roadmapId);
+
+        // then
+        assertEquals(2, results.size());
+    }
+
+    @Test
+    @DisplayName("로드맵 ID로 모든 별점 조회 시, 결과가 없으면 빈 리스트를 반환한다.")
+    void shouldReturnEmptyList_whenGetAllByRoadmapIdIsCalledWithNoResults() {
+        // given
+        Long roadmapId = 100L;
+        when(starRoadMapRepository.findByRoadmapId(roadmapId)).thenReturn(List.of());
+
+        // when
+        var results = starRoadMapQueryServiceAdapter.getAllStarByRoadMapId(roadmapId);
+
+        // then
+        assertTrue(results.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- [이전 PR 리뷰](https://github.com/potenup-kllhy/roadmap/pull/61#discussion_r2521220884)를 반영하여 Command 일괄 수정하였습니다.

## Related Issue
- Issue Number: #46 #58 #60 

## Changes
> 주요 변경사항 bullet

- 도메인 서비스와 어플리케이션 서비스를 분리하였습니다.
- 불필요한 삭제 메서드를 삭제하고 Update와 Delete의 도메인 서비스를 만들었습니다.
- 사용자 별 조회, 로드맵 별 조회 기능을 구현했습니다.

## Discussion Topic
> 의논하고싶은 주제

## Checklist
- [ ] 로컬 테스트 완료
- [ ] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음
