### PR TITLE
feat(roadmap): add roadmap creation, clone api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
@@ -40,7 +39,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testRuntimeOnly 'com.h2database:h2'
     testImplementation("io.github.hakky54:logcaptor:2.12.1")

--- a/src/main/java/com/kllhy/roadmap/common/response/ApiResponse.java
+++ b/src/main/java/com/kllhy/roadmap/common/response/ApiResponse.java
@@ -1,0 +1,23 @@
+package com.kllhy.roadmap.common.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@JsonPropertyOrder({"code", "message", "data"})
+public class ApiResponse<T> {
+    private final String code;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(String code, String message, T data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> of(IResponseCode code, T data) {
+        return ResponseEntity.status(code.getHttpStatus()).body(new ApiResponse<>(code.getCode(), code.getMessage(), data));
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/common/response/ApiResponse.java
+++ b/src/main/java/com/kllhy/roadmap/common/response/ApiResponse.java
@@ -18,6 +18,7 @@ public class ApiResponse<T> {
     }
 
     public static <T> ResponseEntity<ApiResponse<T>> of(IResponseCode code, T data) {
-        return ResponseEntity.status(code.getHttpStatus()).body(new ApiResponse<>(code.getCode(), code.getMessage(), data));
+        return ResponseEntity.status(code.getHttpStatus())
+                .body(new ApiResponse<>(code.getCode(), code.getMessage(), data));
     }
 }

--- a/src/main/java/com/kllhy/roadmap/common/response/IResponseCode.java
+++ b/src/main/java/com/kllhy/roadmap/common/response/IResponseCode.java
@@ -1,0 +1,11 @@
+package com.kllhy.roadmap.common.response;
+
+import org.springframework.http.HttpStatus;
+
+public interface IResponseCode {
+    HttpStatus getHttpStatus();
+
+    String getCode();
+
+    String getMessage();
+}

--- a/src/main/java/com/kllhy/roadmap/common/response/SuccessCode.java
+++ b/src/main/java/com/kllhy/roadmap/common/response/SuccessCode.java
@@ -1,0 +1,30 @@
+package com.kllhy.roadmap.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public enum SuccessCode implements IResponseCode{
+    SUCCESS(HttpStatus.OK, "SUCCESS", "성공했습니다"),
+    CREATED(HttpStatus.CREATED, "CREATED", "생성되었습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/common/response/SuccessCode.java
+++ b/src/main/java/com/kllhy/roadmap/common/response/SuccessCode.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public enum SuccessCode implements IResponseCode{
+public enum SuccessCode implements IResponseCode {
     SUCCESS(HttpStatus.OK, "SUCCESS", "성공했습니다"),
     CREATED(HttpStatus.CREATED, "CREATED", "생성되었습니다");
 

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandService.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandService.java
@@ -5,6 +5,8 @@ import com.kllhy.roadmap.roadmap.domain.model.update_spec.UpdateRoadMap;
 
 public interface RoadMapCommandService {
     long createRoadMap(CreateRoadMapCommand command);
+
     void update(long roadMapId, UpdateRoadMap updateRoadMap);
+
     long cloneRoadMap(long userId, long roadMapId, long categoryId);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandService.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandService.java
@@ -1,7 +1,9 @@
 package com.kllhy.roadmap.roadmap.application.command;
 
+import com.kllhy.roadmap.roadmap.application.command.dto.CreateRoadMapCommand;
 import com.kllhy.roadmap.roadmap.domain.model.update_spec.UpdateRoadMap;
 
 public interface RoadMapCommandService {
+    long createRoadMap(CreateRoadMapCommand command);
     void update(long roadMapId, UpdateRoadMap updateRoadMap);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandService.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandService.java
@@ -6,4 +6,5 @@ import com.kllhy.roadmap.roadmap.domain.model.update_spec.UpdateRoadMap;
 public interface RoadMapCommandService {
     long createRoadMap(CreateRoadMapCommand command);
     void update(long roadMapId, UpdateRoadMap updateRoadMap);
+    long cloneRoadMap(long id);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandService.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandService.java
@@ -6,5 +6,5 @@ import com.kllhy.roadmap.roadmap.domain.model.update_spec.UpdateRoadMap;
 public interface RoadMapCommandService {
     long createRoadMap(CreateRoadMapCommand command);
     void update(long roadMapId, UpdateRoadMap updateRoadMap);
-    long cloneRoadMap(long id);
+    long cloneRoadMap(long userId, long roadMapId, long categoryId);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandServiceAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandServiceAdapter.java
@@ -41,4 +41,15 @@ public class RoadMapCommandServiceAdapter implements RoadMapCommandService {
                                 () -> new DomainException(RoadMapIErrorCode.ROAD_MAP_BAD_REQUEST));
         roadMap.update(updateRoadMap);
     }
+
+    @Transactional
+    public long cloneRoadMap(long id) {
+        RoadMap roadMap =
+                roadMapRepository
+                        .findById(id)
+                        .orElseThrow(
+                                () -> new DomainException(RoadMapIErrorCode.ROAD_MAP_NOT_FOUND))
+                        .cloneAsIs();
+        return roadMapRepository.save(roadMap);
+    }
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandServiceAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandServiceAdapter.java
@@ -22,6 +22,7 @@ public class RoadMapCommandServiceAdapter implements RoadMapCommandService {
     private final CategoryQueryService categoryQueryService;
 
     @Override
+    @Transactional
     public long createRoadMap(CreateRoadMapCommand command) {
         boolean isNotExists = !categoryQueryService.categoryExists(command.categoryId());
         if (isNotExists) {

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandServiceAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/RoadMapCommandServiceAdapter.java
@@ -1,6 +1,10 @@
 package com.kllhy.roadmap.roadmap.application.command;
 
+import com.kllhy.roadmap.category.application.query.CategoryQueryService;
+import com.kllhy.roadmap.category.domain.exception.CategoryErrorCode;
 import com.kllhy.roadmap.common.exception.DomainException;
+import com.kllhy.roadmap.roadmap.application.command.dto.CreateRoadMapCommand;
+import com.kllhy.roadmap.roadmap.application.command.dto.mapper.CreationRoadMapMapper;
 import com.kllhy.roadmap.roadmap.domain.exception.RoadMapIErrorCode;
 import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
 import com.kllhy.roadmap.roadmap.domain.model.update_spec.UpdateRoadMap;
@@ -15,6 +19,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class RoadMapCommandServiceAdapter implements RoadMapCommandService {
 
     private final RoadMapRepository roadMapRepository;
+    private final CategoryQueryService categoryQueryService;
+
+    @Override
+    public long createRoadMap(CreateRoadMapCommand command) {
+        boolean isNotExists = !categoryQueryService.categoryExists(command.categoryId());
+        if (isNotExists) {
+            throw new DomainException(CategoryErrorCode.CATEGORY_NOT_FOUND);
+        }
+        RoadMap roadMap = RoadMap.create(CreationRoadMapMapper.toCreationRoadMap(command));
+        return roadMapRepository.save(roadMap);
+    }
 
     @Override
     public void update(long roadMapId, UpdateRoadMap updateRoadMap) {

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateResourceSubTopicCommand.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateResourceSubTopicCommand.java
@@ -1,0 +1,6 @@
+package com.kllhy.roadmap.roadmap.application.command.dto;
+
+import com.kllhy.roadmap.roadmap.domain.model.enums.ResourceType;
+
+public record CreateResourceSubTopicCommand(
+        String name, int order, ResourceType resourceType, String link) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateResourceTopicCommand.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateResourceTopicCommand.java
@@ -1,0 +1,6 @@
+package com.kllhy.roadmap.roadmap.application.command.dto;
+
+import com.kllhy.roadmap.roadmap.domain.model.enums.ResourceType;
+
+public record CreateResourceTopicCommand(
+        String name, ResourceType resourceType, int order, String link) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateRoadMapCommand.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateRoadMapCommand.java
@@ -3,6 +3,7 @@ package com.kllhy.roadmap.roadmap.application.command.dto;
 import java.util.List;
 
 public record CreateRoadMapCommand(
+        long userId,
         String title,
         String description,
         boolean isDraft,

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateRoadMapCommand.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateRoadMapCommand.java
@@ -8,5 +8,4 @@ public record CreateRoadMapCommand(
         String description,
         boolean isDraft,
         long categoryId,
-        long userId,
         List<CreateTopicCommand> topics) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateRoadMapCommand.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateRoadMapCommand.java
@@ -1,0 +1,11 @@
+package com.kllhy.roadmap.roadmap.application.command.dto;
+
+import java.util.List;
+
+public record CreateRoadMapCommand(
+        String title,
+        String description,
+        boolean isDraft,
+        long categoryId,
+        long userId,
+        List<CreateTopicCommand> topics) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateSubTopicCommand.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateSubTopicCommand.java
@@ -1,0 +1,11 @@
+package com.kllhy.roadmap.roadmap.application.command.dto;
+
+import com.kllhy.roadmap.roadmap.domain.model.enums.ImportanceLevel;
+import java.util.List;
+
+public record CreateSubTopicCommand(
+        String title,
+        String content,
+        ImportanceLevel importanceLevel,
+        boolean isDraft,
+        List<CreateResourceSubTopicCommand> resourceSubTopics) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateTopicCommand.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/CreateTopicCommand.java
@@ -1,0 +1,13 @@
+package com.kllhy.roadmap.roadmap.application.command.dto;
+
+import com.kllhy.roadmap.roadmap.domain.model.enums.ImportanceLevel;
+import java.util.List;
+
+public record CreateTopicCommand(
+        String title,
+        String content,
+        ImportanceLevel importanceLevel,
+        int order,
+        boolean isDraft,
+        List<CreateResourceTopicCommand> resourceTopics,
+        List<CreateSubTopicCommand> subTopics) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/mapper/CreationRoadMapMapper.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/command/dto/mapper/CreationRoadMapMapper.java
@@ -1,0 +1,99 @@
+package com.kllhy.roadmap.roadmap.application.command.dto.mapper;
+
+import com.kllhy.roadmap.roadmap.application.command.dto.*;
+import com.kllhy.roadmap.roadmap.domain.model.creation_spec.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CreationRoadMapMapper {
+    public static CreationRoadMap toCreationRoadMap(CreateRoadMapCommand command) {
+        return new CreationRoadMap(
+                command.title(),
+                command.description(),
+                command.isDraft(),
+                command.categoryId(),
+                command.userId(),
+                mapTopics(command.topics()));
+    }
+
+    private static List<CreationTopic> mapTopics(List<CreateTopicCommand> commands) {
+        if (commands == null || commands.isEmpty()) {
+            return List.of();
+        }
+
+        List<CreationTopic> topics = new ArrayList<>();
+        for (CreateTopicCommand command : commands) {
+            topics.add(toTopic(command));
+        }
+        return topics;
+    }
+
+    private static CreationTopic toTopic(CreateTopicCommand command) {
+        return new CreationTopic(
+                command.title(),
+                command.content(),
+                command.importanceLevel(),
+                command.order(),
+                command.isDraft(),
+                mapResourceTopics(command.resourceTopics()),
+                mapSubTopics(command.subTopics()));
+    }
+
+    private static List<CreationResourceTopic> mapResourceTopics(
+            List<CreateResourceTopicCommand> commands) {
+        if (commands == null || commands.isEmpty()) {
+            return List.of();
+        }
+
+        List<CreationResourceTopic> resourceTopics = new ArrayList<>();
+        for (CreateResourceTopicCommand command : commands) {
+            resourceTopics.add(toResourceTopic(command));
+        }
+        return resourceTopics;
+    }
+
+    private static CreationResourceTopic toResourceTopic(CreateResourceTopicCommand command) {
+        return new CreationResourceTopic(
+                command.name(), command.resourceType(), command.order(), command.link());
+    }
+
+    private static List<CreationSubTopic> mapSubTopics(List<CreateSubTopicCommand> commands) {
+        if (commands == null || commands.isEmpty()) {
+            return List.of();
+        }
+
+        List<CreationSubTopic> subTopics = new ArrayList<>();
+        for (CreateSubTopicCommand command : commands) {
+            subTopics.add(toSubTopic(command));
+        }
+        return subTopics;
+    }
+
+    private static CreationSubTopic toSubTopic(CreateSubTopicCommand command) {
+        return new CreationSubTopic(
+                command.title(),
+                command.content(),
+                command.importanceLevel(),
+                command.isDraft(),
+                mapResourceSubTopics(command.resourceSubTopics()));
+    }
+
+    private static List<CreationResourceSubTopic> mapResourceSubTopics(
+            List<CreateResourceSubTopicCommand> commands) {
+        if (commands == null || commands.isEmpty()) {
+            return List.of();
+        }
+
+        List<CreationResourceSubTopic> resourceSubTopics = new ArrayList<>();
+        for (CreateResourceSubTopicCommand command : commands) {
+            resourceSubTopics.add(toResourceSubTopic(command));
+        }
+        return resourceSubTopics;
+    }
+
+    private static CreationResourceSubTopic toResourceSubTopic(
+            CreateResourceSubTopicCommand command) {
+        return new CreationResourceSubTopic(
+                command.name(), command.order(), command.resourceType(), command.link());
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/RoadMapQueryService.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/RoadMapQueryService.java
@@ -6,4 +6,6 @@ public interface RoadMapQueryService {
     RoadMapView findById(Long id);
 
     boolean existsById(Long id);
+
+    RoadMapView findByIdWithAssociations(long id);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/RoadMapQueryServiceAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/RoadMapQueryServiceAdapter.java
@@ -32,8 +32,7 @@ public class RoadMapQueryServiceAdapter implements RoadMapQueryService {
 
     @Override
     public RoadMapView findByIdWithAssociations(long id) {
-        RoadMap roadMap = roadMapRepository.findByIdWithAssociations(id)
-                .orElseThrow(() -> new DomainException(RoadMapIErrorCode.ROAD_MAP_BAD_REQUEST));
+        RoadMap roadMap = roadMapRepository.findByIdWithAssociations(id);
 
         return RoadMapViewMapper.toView(roadMap);
     }

--- a/src/main/java/com/kllhy/roadmap/roadmap/application/query/RoadMapQueryServiceAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/application/query/RoadMapQueryServiceAdapter.java
@@ -29,4 +29,12 @@ public class RoadMapQueryServiceAdapter implements RoadMapQueryService {
     public boolean existsById(Long id) {
         return roadMapRepository.existsById(id);
     }
+
+    @Override
+    public RoadMapView findByIdWithAssociations(long id) {
+        RoadMap roadMap = roadMapRepository.findByIdWithAssociations(id)
+                .orElseThrow(() -> new DomainException(RoadMapIErrorCode.ROAD_MAP_BAD_REQUEST));
+
+        return RoadMapViewMapper.toView(roadMap);
+    }
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/exception/RoadMapIErrorCode.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/exception/RoadMapIErrorCode.java
@@ -10,6 +10,8 @@ public enum RoadMapIErrorCode implements IErrorCode {
             DomainHttpStatus.INTERNAL_SERVER_ERROR, "ROAD_MAP_003", "500 internal server error"),
     ROAD_MAP_NOT_FOUND(DomainHttpStatus.NOT_FOUND, "ROAD_MAP_004", "404 not found"),
     ROAD_MAP_CLONE_NOT_ALLOWED(DomainHttpStatus.CONFLICT, "ROAD_MAP_005", "409 clone not allowed"),
+    ROAD_MAP_USER_NOT_ACTIVE(DomainHttpStatus.NOT_FOUND, "ROAD_MAP_006", "user not active"),
+    ROAD_MAP_CATEGORY_NOT_FOUND(DomainHttpStatus.NOT_FOUND, "ROAD_MAP_007", "category not active"),
     ;
 
     private final DomainHttpStatus httpStatus;

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/exception/RoadMapIErrorCode.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/exception/RoadMapIErrorCode.java
@@ -9,6 +9,7 @@ public enum RoadMapIErrorCode implements IErrorCode {
     ROAD_MAP_INTERNAL_SERVER_ERROR(
             DomainHttpStatus.INTERNAL_SERVER_ERROR, "ROAD_MAP_003", "500 internal server error"),
     ROAD_MAP_NOT_FOUND(DomainHttpStatus.NOT_FOUND, "ROAD_MAP_004", "404 not found"),
+    ROAD_MAP_CLONE_NOT_ALLOWED(DomainHttpStatus.CONFLICT, "ROAD_MAP_005", "409 clone not allowed"),
     ;
 
     private final DomainHttpStatus httpStatus;

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/ResourceSubTopic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/ResourceSubTopic.java
@@ -43,7 +43,6 @@ public class ResourceSubTopic extends IdEntity {
         this.order = order;
         this.resourceType = resourceType;
         this.link = link;
-
         this.subTopic = null;
     }
 
@@ -105,5 +104,9 @@ public class ResourceSubTopic extends IdEntity {
         this.subTopic =
                 Objects.requireNonNull(
                         subTopic, "ResourceSubTopic.setSubTopic: 파라미터 subTopic 이 null 입니다");
+    }
+
+    public CreationResourceSubTopic cloneAsIs() {
+        return new CreationResourceSubTopic(name, order, resourceType, link);
     }
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/ResourceTopic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/ResourceTopic.java
@@ -103,6 +103,10 @@ public class ResourceTopic extends IdEntity {
         }
     }
 
+    CreationResourceTopic cloneAsIs() {
+        return new CreationResourceTopic(name, resourceType, order, link);
+    }
+
     void setTopic(Topic topic) {
         this.topic = Objects.requireNonNull(topic, "ResourceTopic.setTopic: 파라미터 topic 이 null 입니다");
     }

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
@@ -1,6 +1,13 @@
 package com.kllhy.roadmap.roadmap.domain.model;
 
+import com.kllhy.roadmap.common.exception.DomainException;
 import com.kllhy.roadmap.common.model.AggregateRoot;
+import com.kllhy.roadmap.roadmap.domain.event.RoadMapEventOccurred;
+import com.kllhy.roadmap.roadmap.domain.event.SubTopicEventOccurred;
+import com.kllhy.roadmap.roadmap.domain.event.TopicEventOccurred;
+import com.kllhy.roadmap.roadmap.domain.event.enums.ActiveStatus;
+import com.kllhy.roadmap.roadmap.domain.event.enums.EventType;
+import com.kllhy.roadmap.roadmap.domain.exception.RoadMapIErrorCode;
 import com.kllhy.roadmap.roadmap.domain.model.creation_spec.CreationRoadMap;
 import com.kllhy.roadmap.roadmap.domain.model.creation_spec.CreationTopic;
 import com.kllhy.roadmap.roadmap.domain.model.update_spec.UpdateRoadMap;
@@ -53,11 +60,13 @@ public class RoadMap extends AggregateRoot {
     private List<Topic> topics = new ArrayList<>();
 
     private RoadMap(
+            UUID uuid,
             String title,
             String description,
             boolean isDraft,
             Long categoryId,
             List<Topic> topics) {
+        this.uuid = uuid;
         this.title = title;
         this.description = description;
         this.isDraft = isDraft;

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
@@ -2,6 +2,7 @@ package com.kllhy.roadmap.roadmap.domain.model;
 
 import com.kllhy.roadmap.common.model.AggregateRoot;
 import com.kllhy.roadmap.roadmap.domain.model.creation_spec.CreationRoadMap;
+import com.kllhy.roadmap.roadmap.domain.model.creation_spec.CreationTopic;
 import com.kllhy.roadmap.roadmap.domain.model.update_spec.UpdateRoadMap;
 import com.kllhy.roadmap.roadmap.domain.model.update_spec.UpdateTopic;
 import jakarta.persistence.*;
@@ -223,7 +224,7 @@ public class RoadMap extends AggregateRoot {
         }
     }
 
-    public RoadMap cloneAsIs() {
+    public RoadMap cloneAsIs(long userId) {
         if (isDraft || isDeleted) {
             throw new DomainException(RoadMapIErrorCode.ROAD_MAP_CLONE_NOT_ALLOWED);
         }
@@ -238,7 +239,7 @@ public class RoadMap extends AggregateRoot {
         }
 
         CreationRoadMap clonedRoadMap =
-                new CreationRoadMap(title, description, isDraft, categoryId, topics);
+                new CreationRoadMap(title, description, isDraft, categoryId, userId, topics);
         return RoadMap.create(clonedRoadMap);
     }
 

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/SubTopic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/SubTopic.java
@@ -201,6 +201,19 @@ public class SubTopic extends IdAuditEntity {
         }
     }
 
+    boolean isCloneable() {
+        return !(isDraft || isDeleted);
+    }
+
+    public CreationSubTopic cloneAsIs() {
+        return new CreationSubTopic(
+                this.title,
+                this.content,
+                this.importanceLevel,
+                this.isDraft,
+                this.resources.stream().map(ResourceSubTopic::cloneAsIs).toList());
+    }
+
     void setTopic(Topic topic) {
         this.topic = Objects.requireNonNull(topic, "SubTopic.setTopic: 파라미터 topic 이 null 입니다");
     }

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/repository/RoadMapRepository.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/repository/RoadMapRepository.java
@@ -9,4 +9,6 @@ public interface RoadMapRepository {
     boolean existsById(long id);
 
     long save(RoadMap roadMap);
+
+    Optional<RoadMap> findByIdWithAssociations(long id);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/repository/RoadMapRepository.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/repository/RoadMapRepository.java
@@ -5,6 +5,6 @@ import java.util.Optional;
 
 public interface RoadMapRepository {
     Optional<RoadMap> findById(long id);
-
     boolean existsById(long id);
+    long save(RoadMap roadMap);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/repository/RoadMapRepository.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/repository/RoadMapRepository.java
@@ -10,5 +10,5 @@ public interface RoadMapRepository {
 
     long save(RoadMap roadMap);
 
-    Optional<RoadMap> findByIdWithAssociations(long id);
+    RoadMap findByIdWithAssociations(long id);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/repository/RoadMapRepository.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/repository/RoadMapRepository.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 public interface RoadMapRepository {
     Optional<RoadMap> findById(long id);
+
     boolean existsById(long id);
+
     long save(RoadMap roadMap);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/service/RoadMapCloneService.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/service/RoadMapCloneService.java
@@ -1,0 +1,23 @@
+package com.kllhy.roadmap.roadmap.domain.service;
+
+import com.kllhy.roadmap.common.annotation.DomainService;
+import com.kllhy.roadmap.common.exception.DomainException;
+import com.kllhy.roadmap.roadmap.domain.exception.RoadMapIErrorCode;
+import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
+import com.kllhy.roadmap.user.domain.enums.AccountStatus;
+import com.kllhy.roadmap.user.service.view.UserView;
+
+@DomainService
+public class RoadMapCloneService {
+    public RoadMap cloneAsIs(UserView user, boolean isCategoryExists, RoadMap roadMap) {
+        if (!user.status().equals(AccountStatus.ACTIVE)) {
+            throw new DomainException(RoadMapIErrorCode.ROAD_MAP_USER_NOT_ACTIVE);
+        }
+
+        if (!isCategoryExists) {
+            throw new DomainException(RoadMapIErrorCode.ROAD_MAP_CATEGORY_NOT_FOUND);
+        }
+
+        return roadMap.cloneAsIs(user.id());
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/service/RoadMapCreationService.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/service/RoadMapCreationService.java
@@ -1,0 +1,24 @@
+package com.kllhy.roadmap.roadmap.domain.service;
+
+import com.kllhy.roadmap.common.annotation.DomainService;
+import com.kllhy.roadmap.common.exception.DomainException;
+import com.kllhy.roadmap.roadmap.domain.exception.RoadMapIErrorCode;
+import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
+import com.kllhy.roadmap.roadmap.domain.model.creation_spec.CreationRoadMap;
+import com.kllhy.roadmap.user.domain.enums.AccountStatus;
+import com.kllhy.roadmap.user.service.view.UserView;
+
+@DomainService
+public class RoadMapCreationService {
+    public RoadMap create(UserView user, boolean isCategoryExists, CreationRoadMap creation) {
+        if (!user.status().equals(AccountStatus.ACTIVE)) {
+            throw new DomainException(RoadMapIErrorCode.ROAD_MAP_USER_NOT_ACTIVE);
+        }
+
+        if (!isCategoryExists) {
+            throw new DomainException(RoadMapIErrorCode.ROAD_MAP_CATEGORY_NOT_FOUND);
+        }
+
+        return RoadMap.create(creation);
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepository.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepository.java
@@ -2,20 +2,17 @@ package com.kllhy.roadmap.roadmap.infrastructure.jpa;
 
 import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface RoadMapJpaRepository extends JpaRepository<RoadMap, Long> {
 
-    @EntityGraph(
-            attributePaths = {
-                "topics",
-                "topics.resources",
-                "topics.subTopics",
-                "topics.subTopics.resources"
-            })
-    @Query("select r from RoadMap r where r.id = :id")
-    Optional<RoadMap> findByIdWithAssociations(@Param("id") Long id);
+    @Query(
+            """
+        select distinct r from RoadMap r
+        left join fetch r.topics t
+        where r.id = :id
+        """)
+    Optional<RoadMap> findWithTopics(@Param("id") Long id);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepository.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepository.java
@@ -4,6 +4,8 @@ import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RoadMapJpaRepository extends JpaRepository<RoadMap, Long> {
 
@@ -14,5 +16,6 @@ public interface RoadMapJpaRepository extends JpaRepository<RoadMap, Long> {
                 "topics.subTopics",
                 "topics.subTopics.resources"
             })
-    Optional<RoadMap> findByIdWithAssociations(Long id);
+    @Query("select r from RoadMap r where r.id = :id")
+    Optional<RoadMap> findByIdWithAssociations(@Param("id") Long id);
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
@@ -16,6 +16,7 @@ public class RoadMapJpaRepositoryAdapter implements RoadMapRepository {
         // TODO: 현재 LAZY 전략으로 전체 조회가 불가능한데, 추후 한번에 전체 조회 가능하도록 변경해 놓겠습니다
         return roadMapJpaRepository.findById(id);
     }
+
     @Override
     public long save(RoadMap roadMap) {
         return roadMapJpaRepository.save(roadMap).getId();

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
@@ -3,6 +3,10 @@ package com.kllhy.roadmap.roadmap.infrastructure.jpa;
 import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
 import com.kllhy.roadmap.roadmap.domain.repository.RoadMapRepository;
 import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -13,7 +17,6 @@ public class RoadMapJpaRepositoryAdapter implements RoadMapRepository {
 
     @Override
     public Optional<RoadMap> findById(long id) {
-        // TODO: 현재 LAZY 전략으로 전체 조회가 불가능한데, 추후 한번에 전체 조회 가능하도록 변경해 놓겠습니다
         return roadMapJpaRepository.findById(id);
     }
 

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
@@ -30,6 +30,7 @@ public class RoadMapJpaRepositoryAdapter implements RoadMapRepository {
         return roadMapJpaRepository.existsById(id);
     }
 
+    @Override
     public Optional<RoadMap> findByIdWithAssociations(long id) {
         return roadMapJpaRepository.findByIdWithAssociations(id);
     }

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
@@ -3,10 +3,6 @@ package com.kllhy.roadmap.roadmap.infrastructure.jpa;
 import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
 import com.kllhy.roadmap.roadmap.domain.repository.RoadMapRepository;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,6 +10,8 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class RoadMapJpaRepositoryAdapter implements RoadMapRepository {
     private final RoadMapJpaRepository roadMapJpaRepository;
+    private final TopicJpaRepository topicJpaRepository;
+    private final SubTopicJpaRepository subTopicJpaRepository;
 
     @Override
     public Optional<RoadMap> findById(long id) {
@@ -31,7 +29,16 @@ public class RoadMapJpaRepositoryAdapter implements RoadMapRepository {
     }
 
     @Override
-    public Optional<RoadMap> findByIdWithAssociations(long id) {
-        return roadMapJpaRepository.findByIdWithAssociations(id);
+    public RoadMap findByIdWithAssociations(long id) {
+        RoadMap roadMap =
+                roadMapJpaRepository
+                        .findWithTopics(id)
+                        .orElseThrow(
+                                () -> new IllegalArgumentException("RoadMap not found: " + id));
+
+        topicJpaRepository.findAllWithResourcesByRoadMapId(id);
+        topicJpaRepository.findAllWithSubTopicsByRoadMapId(id);
+        subTopicJpaRepository.findAllWithResourceSubTopicsByRoadMapId(id);
+        return roadMap;
     }
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
@@ -16,6 +16,10 @@ public class RoadMapJpaRepositoryAdapter implements RoadMapRepository {
         // TODO: 현재 LAZY 전략으로 전체 조회가 불가능한데, 추후 한번에 전체 조회 가능하도록 변경해 놓겠습니다
         return roadMapJpaRepository.findById(id);
     }
+    @Override
+    public long save(RoadMap roadMap) {
+        return roadMapJpaRepository.save(roadMap).getId();
+    }
 
     @Override
     public boolean existsById(long id) {

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/RoadMapJpaRepositoryAdapter.java
@@ -1,5 +1,7 @@
 package com.kllhy.roadmap.roadmap.infrastructure.jpa;
 
+import com.kllhy.roadmap.common.exception.DomainException;
+import com.kllhy.roadmap.roadmap.domain.exception.RoadMapIErrorCode;
 import com.kllhy.roadmap.roadmap.domain.model.RoadMap;
 import com.kllhy.roadmap.roadmap.domain.repository.RoadMapRepository;
 import java.util.Optional;
@@ -34,7 +36,7 @@ public class RoadMapJpaRepositoryAdapter implements RoadMapRepository {
                 roadMapJpaRepository
                         .findWithTopics(id)
                         .orElseThrow(
-                                () -> new IllegalArgumentException("RoadMap not found: " + id));
+                                () -> new DomainException(RoadMapIErrorCode.ROAD_MAP_NOT_FOUND));
 
         topicJpaRepository.findAllWithResourcesByRoadMapId(id);
         topicJpaRepository.findAllWithSubTopicsByRoadMapId(id);

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/SubTopicJpaRepository.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/SubTopicJpaRepository.java
@@ -1,0 +1,17 @@
+package com.kllhy.roadmap.roadmap.infrastructure.jpa;
+
+import com.kllhy.roadmap.roadmap.domain.model.SubTopic;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SubTopicJpaRepository extends JpaRepository<SubTopic, Long> {
+    @Query(
+            """
+        select distinct st from SubTopic st
+        left join fetch st.resources srt
+        where st.topic.roadMap.id = :roadMapId
+        """)
+    List<SubTopic> findAllWithResourceSubTopicsByRoadMapId(@Param("roadMapId") Long roadMapId);
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/TopicJpaRepository.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/infrastructure/jpa/TopicJpaRepository.java
@@ -1,0 +1,25 @@
+package com.kllhy.roadmap.roadmap.infrastructure.jpa;
+
+import com.kllhy.roadmap.roadmap.domain.model.Topic;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface TopicJpaRepository extends JpaRepository<Topic, Long> {
+    @Query(
+            """
+        select distinct t from Topic t
+        left join fetch t.resources rt
+        where t.roadMap.id = :roadMapId
+        """)
+    List<Topic> findAllWithResourcesByRoadMapId(@Param("roadMapId") Long roadMapId);
+
+    @Query(
+            """
+        select distinct t from Topic t
+        left join fetch t.subTopics st
+        where t.roadMap.id = :roadMapId
+        """)
+    List<Topic> findAllWithSubTopicsByRoadMapId(@Param("roadMapId") Long roadMapId);
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/RoadMapController.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/RoadMapController.java
@@ -3,6 +3,7 @@ package com.kllhy.roadmap.roadmap.presentation;
 import com.kllhy.roadmap.common.response.ApiResponse;
 import com.kllhy.roadmap.common.response.SuccessCode;
 import com.kllhy.roadmap.roadmap.application.command.RoadMapCommandService;
+import com.kllhy.roadmap.roadmap.presentation.dto.RoadMapCloneRequest;
 import com.kllhy.roadmap.roadmap.presentation.dto.RoadMapCreateRequest;
 import com.kllhy.roadmap.roadmap.presentation.dto.mapper.CreateRoadMapCommandMapper;
 import jakarta.validation.Valid;
@@ -25,11 +26,13 @@ public class RoadMapController {
         return ApiResponse.of(SuccessCode.SUCCESS, new RoadMapCreateResponse(id));
     }
 
+    record RoadMapCreateResponse(long id) {}
+
     @PostMapping("/{id}/clone")
-    public ResponseEntity<?> cloneRoadMap(@PathVariable("id") long id) {
-        long cloneRoadMapId = roadMapCommandService.cloneRoadMap(id);
+    public ResponseEntity<?> cloneRoadMap(
+            @PathVariable("id") long id, @RequestBody @Valid RoadMapCloneRequest request) {
+        long cloneRoadMapId =
+                roadMapCommandService.cloneRoadMap(id, request.userId(), request.categoryId());
         return ApiResponse.of(SuccessCode.SUCCESS, new RoadMapCreateResponse(cloneRoadMapId));
     }
-
-    record RoadMapCreateResponse(long id) {}
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/RoadMapController.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/RoadMapController.java
@@ -8,10 +8,7 @@ import com.kllhy.roadmap.roadmap.presentation.dto.mapper.CreateRoadMapCommandMap
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api-v1/roadmap")
@@ -20,11 +17,18 @@ public class RoadMapController {
     private final RoadMapCommandService roadMapCommandService;
 
     @PostMapping
-    public ResponseEntity<?> createRoadMap(@Valid @RequestBody RoadMapCreateRequest request) {
+    public ResponseEntity<ApiResponse<RoadMapCreateResponse>> createRoadMap(
+            @Valid @RequestBody RoadMapCreateRequest request) {
         long id =
                 roadMapCommandService.createRoadMap(
                         CreateRoadMapCommandMapper.mapCreateRoadMapCommand(request));
         return ApiResponse.of(SuccessCode.SUCCESS, new RoadMapCreateResponse(id));
+    }
+
+    @PostMapping("/{id}/clone")
+    public ResponseEntity<?> cloneRoadMap(@PathVariable("id") long id) {
+        long cloneRoadMapId = roadMapCommandService.cloneRoadMap(id);
+        return ApiResponse.of(SuccessCode.SUCCESS, new RoadMapCreateResponse(cloneRoadMapId));
     }
 
     record RoadMapCreateResponse(long id) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/RoadMapController.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/RoadMapController.java
@@ -1,0 +1,27 @@
+package com.kllhy.roadmap.roadmap.presentation;
+
+import com.kllhy.roadmap.roadmap.application.command.RoadMapCommandService;
+import com.kllhy.roadmap.roadmap.presentation.dto.RoadMapCreateRequest;
+import com.kllhy.roadmap.roadmap.presentation.dto.mapper.CreateRoadMapCommandMapper;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api-v1/roadmap")
+@RequiredArgsConstructor
+public class RoadMapController {
+    private final RoadMapCommandService roadMapCommandService;
+
+    @PostMapping
+    public ResponseEntity<?> createRoadMap(@Valid @RequestBody RoadMapCreateRequest request) {
+        long id =
+                roadMapCommandService.createRoadMap(
+                        CreateRoadMapCommandMapper.mapCreateRoadMapCommand(request));
+        return ResponseEntity.ok().body(id);
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/RoadMapController.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/RoadMapController.java
@@ -3,6 +3,8 @@ package com.kllhy.roadmap.roadmap.presentation;
 import com.kllhy.roadmap.common.response.ApiResponse;
 import com.kllhy.roadmap.common.response.SuccessCode;
 import com.kllhy.roadmap.roadmap.application.command.RoadMapCommandService;
+import com.kllhy.roadmap.roadmap.application.query.RoadMapQueryService;
+import com.kllhy.roadmap.roadmap.application.query.dto.RoadMapView;
 import com.kllhy.roadmap.roadmap.presentation.dto.RoadMapCloneRequest;
 import com.kllhy.roadmap.roadmap.presentation.dto.RoadMapCreateRequest;
 import com.kllhy.roadmap.roadmap.presentation.dto.mapper.CreateRoadMapCommandMapper;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class RoadMapController {
     private final RoadMapCommandService roadMapCommandService;
+    private final RoadMapQueryService roadMapQueryService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<RoadMapCreateResponse>> createRoadMap(
@@ -34,5 +37,11 @@ public class RoadMapController {
         long cloneRoadMapId =
                 roadMapCommandService.cloneRoadMap(id, request.userId(), request.categoryId());
         return ApiResponse.of(SuccessCode.SUCCESS, new RoadMapCreateResponse(cloneRoadMapId));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getRoadMapById(@PathVariable("id") long id) {
+        RoadMapView view = roadMapQueryService.findByIdWithAssociations(id);
+        return ApiResponse.of(SuccessCode.SUCCESS, view);
     }
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/RoadMapController.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/RoadMapController.java
@@ -1,5 +1,7 @@
 package com.kllhy.roadmap.roadmap.presentation;
 
+import com.kllhy.roadmap.common.response.ApiResponse;
+import com.kllhy.roadmap.common.response.SuccessCode;
 import com.kllhy.roadmap.roadmap.application.command.RoadMapCommandService;
 import com.kllhy.roadmap.roadmap.presentation.dto.RoadMapCreateRequest;
 import com.kllhy.roadmap.roadmap.presentation.dto.mapper.CreateRoadMapCommandMapper;
@@ -22,6 +24,8 @@ public class RoadMapController {
         long id =
                 roadMapCommandService.createRoadMap(
                         CreateRoadMapCommandMapper.mapCreateRoadMapCommand(request));
-        return ResponseEntity.ok().body(id);
+        return ApiResponse.of(SuccessCode.SUCCESS, new RoadMapCreateResponse(id));
     }
+
+    record RoadMapCreateResponse(long id) {}
 }

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/ResourceSubTopicCreateRequest.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/ResourceSubTopicCreateRequest.java
@@ -7,4 +7,4 @@ public record ResourceSubTopicCreateRequest(
         @NotBlank @Size(max = 255) String name,
         @NotNull @PositiveOrZero Integer order,
         @NotNull ResourceType resourceType,
-        @NotBlank @Size(max = 255) @Pattern(regexp = "^https?://.+$^") String link) {}
+        @NotBlank @Size(max = 255) @Pattern(regexp = "^https?://.+$") String link) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/ResourceSubTopicCreateRequest.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/ResourceSubTopicCreateRequest.java
@@ -1,0 +1,10 @@
+package com.kllhy.roadmap.roadmap.presentation.dto;
+
+import com.kllhy.roadmap.roadmap.domain.model.enums.ResourceType;
+import jakarta.validation.constraints.*;
+
+public record ResourceSubTopicCreateRequest(
+        @NotBlank @Size(max = 255) String name,
+        @NotNull @PositiveOrZero Integer order,
+        @NotNull ResourceType resourceType,
+        @NotBlank @Size(max = 255) @Pattern(regexp = "^https?://.+$^") String link) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/ResourceTopicCreateRequest.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/ResourceTopicCreateRequest.java
@@ -7,4 +7,4 @@ public record ResourceTopicCreateRequest(
         @Size(min = 1) String name,
         @NotNull ResourceType resourceType,
         @NotNull @Positive Integer order,
-        @NotBlank @Size(max = 255) @Pattern(regexp = "^https?://.+$^") String link) {}
+        @NotBlank @Size(max = 255) @Pattern(regexp = "^https?://.+$") String link) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/ResourceTopicCreateRequest.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/ResourceTopicCreateRequest.java
@@ -1,0 +1,10 @@
+package com.kllhy.roadmap.roadmap.presentation.dto;
+
+import com.kllhy.roadmap.roadmap.domain.model.enums.ResourceType;
+import jakarta.validation.constraints.*;
+
+public record ResourceTopicCreateRequest(
+        @Size(min = 1) String name,
+        @NotNull ResourceType resourceType,
+        @NotNull @Positive Integer order,
+        @NotBlank @Size(max = 255) @Pattern(regexp = "^https?://.+$^") String link) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/RoadMapCloneRequest.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/RoadMapCloneRequest.java
@@ -1,0 +1,5 @@
+package com.kllhy.roadmap.roadmap.presentation.dto;
+
+import jakarta.validation.constraints.Min;
+
+public record RoadMapCloneRequest(@Min(1) long userId, @Min(1) long categoryId) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/RoadMapCreateRequest.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/RoadMapCreateRequest.java
@@ -1,0 +1,14 @@
+package com.kllhy.roadmap.roadmap.presentation.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import java.util.List;
+
+public record RoadMapCreateRequest(
+        @Min(1)
+        long userId,
+        @NotBlank @Size(max = 255) String title,
+        @Size(max = 255) String description,
+        boolean isDraft,
+        @NotNull @Positive Long categoryId,
+        @NotNull @Size(min = 1) @Valid List<TopicCreateRequest> topics) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/RoadMapCreateRequest.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/RoadMapCreateRequest.java
@@ -5,8 +5,7 @@ import jakarta.validation.constraints.*;
 import java.util.List;
 
 public record RoadMapCreateRequest(
-        @Min(1)
-        long userId,
+        @Min(1) long userId,
         @NotBlank @Size(max = 255) String title,
         @Size(max = 255) String description,
         boolean isDraft,

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/SubTopicCreateRequest.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/SubTopicCreateRequest.java
@@ -1,0 +1,13 @@
+package com.kllhy.roadmap.roadmap.presentation.dto;
+
+import com.kllhy.roadmap.roadmap.domain.model.enums.ImportanceLevel;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import java.util.List;
+
+public record SubTopicCreateRequest(
+        @NotBlank @Size(max = 255) String title,
+        @Size(max = 255) String content,
+        @NotNull ImportanceLevel importanceLevel,
+        boolean isDraft,
+        @Valid List<ResourceSubTopicCreateRequest> resources) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/TopicCreateRequest.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/TopicCreateRequest.java
@@ -1,0 +1,15 @@
+package com.kllhy.roadmap.roadmap.presentation.dto;
+
+import com.kllhy.roadmap.roadmap.domain.model.enums.ImportanceLevel;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import java.util.List;
+
+public record TopicCreateRequest(
+        @NotBlank @Size(max = 255) String title,
+        @Size(max = 255) String content,
+        @NotNull ImportanceLevel importanceLevel,
+        @NotNull @Positive Integer order,
+        boolean isDraft,
+        @Valid List<ResourceTopicCreateRequest> resources,
+        @Valid List<SubTopicCreateRequest> subTopics) {}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/mapper/CreateRoadMapCommandMapper.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/mapper/CreateRoadMapCommandMapper.java
@@ -12,7 +12,6 @@ public class CreateRoadMapCommandMapper {
                 request.description(),
                 request.isDraft(),
                 request.categoryId(),
-                request.userId(),
                 Optional.ofNullable(request.topics()).orElseGet(Collections::emptyList).stream()
                         .filter(Objects::nonNull)
                         .map(CreateRoadMapCommandMapper::toCreateTopicCommand)

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/mapper/CreateRoadMapCommandMapper.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/mapper/CreateRoadMapCommandMapper.java
@@ -1,0 +1,61 @@
+package com.kllhy.roadmap.roadmap.presentation.dto.mapper;
+
+import com.kllhy.roadmap.roadmap.application.command.dto.*;
+import com.kllhy.roadmap.roadmap.presentation.dto.*;
+import java.util.*;
+
+public class CreateRoadMapCommandMapper {
+    public static CreateRoadMapCommand mapCreateRoadMapCommand(RoadMapCreateRequest request) {
+        return new CreateRoadMapCommand(
+                request.title(),
+                request.description(),
+                request.isDraft(),
+                request.categoryId(),
+                request.userId(),
+                Optional.ofNullable(request.topics()).orElseGet(Collections::emptyList).stream()
+                        .filter(Objects::nonNull)
+                        .map(CreateRoadMapCommandMapper::toCreateTopicCommand)
+                        .toList());
+    }
+
+    private static CreateTopicCommand toCreateTopicCommand(TopicCreateRequest request) {
+        return new CreateTopicCommand(
+                request.title(),
+                request.content(),
+                request.importanceLevel(),
+                request.order(),
+                request.isDraft(),
+                Optional.ofNullable(request.resources()).orElseGet(Collections::emptyList).stream()
+                        .filter(Objects::nonNull)
+                        .map(CreateRoadMapCommandMapper::toCreateResourceTopicCommand)
+                        .toList(),
+                Optional.ofNullable(request.subTopics()).orElseGet(Collections::emptyList).stream()
+                        .filter(Objects::nonNull)
+                        .map(CreateRoadMapCommandMapper::toCreateSubTopicCommand)
+                        .toList());
+    }
+
+    private static CreateResourceTopicCommand toCreateResourceTopicCommand(
+            ResourceTopicCreateRequest request) {
+        return new CreateResourceTopicCommand(
+                request.name(), request.resourceType(), request.order(), request.link());
+    }
+
+    private static CreateSubTopicCommand toCreateSubTopicCommand(SubTopicCreateRequest request) {
+        return new CreateSubTopicCommand(
+                request.title(),
+                request.content(),
+                request.importanceLevel(),
+                request.isDraft(),
+                Optional.ofNullable(request.resources()).orElseGet(Collections::emptyList).stream()
+                        .filter(Objects::nonNull)
+                        .map(CreateRoadMapCommandMapper::toCreateResourceSubTopicCommand)
+                        .toList());
+    }
+
+    private static CreateResourceSubTopicCommand toCreateResourceSubTopicCommand(
+            ResourceSubTopicCreateRequest request) {
+        return new CreateResourceSubTopicCommand(
+                request.name(), request.order(), request.resourceType(), request.link());
+    }
+}

--- a/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/mapper/CreateRoadMapCommandMapper.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/presentation/dto/mapper/CreateRoadMapCommandMapper.java
@@ -7,6 +7,7 @@ import java.util.*;
 public class CreateRoadMapCommandMapper {
     public static CreateRoadMapCommand mapCreateRoadMapCommand(RoadMapCreateRequest request) {
         return new CreateRoadMapCommand(
+                request.userId(),
                 request.title(),
                 request.description(),
                 request.isDraft(),

--- a/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapCreateTest.java
+++ b/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapCreateTest.java
@@ -52,7 +52,7 @@ class RoadMapCreateTest {
         // when & then
         assertThatThrownBy(() -> RoadMap.create(creationRoadMap))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("creationTopics 가 blank 임");
+                .hasMessageContaining("RoadMap.validateTopics: topics 가 blank 임");
     }
 
     @Test

--- a/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapCreateTest.java
+++ b/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapCreateTest.java
@@ -1,14 +1,13 @@
 package com.kllhy.roadmap.roadmap.domain.model;
 
+import static org.assertj.core.api.Assertions.*;
+
 import com.kllhy.roadmap.roadmap.domain.model.creation_spec.*;
 import com.kllhy.roadmap.roadmap.domain.model.enums.ImportanceLevel;
 import com.kllhy.roadmap.roadmap.domain.model.enums.ResourceType;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.*;
 
 class RoadMapCreateTest {
     @Test
@@ -37,7 +36,7 @@ class RoadMapCreateTest {
         var testSubTopic = rm.getTopics().get(0).getSubTopics().get(0);
         assertThat(testSubTopic.getTitle()).isEqualTo("프로젝트 스캐폴딩");
         assertThat(testSubTopic.getContent()).isEqualTo("start.spring.io 사용");
-        assertThat(testSubTopic.getImportanceLevel()).isEqualTo( ImportanceLevel.DEFAULT);
+        assertThat(testSubTopic.getImportanceLevel()).isEqualTo(ImportanceLevel.DEFAULT);
         assertThat(testSubTopic.getIsDraft()).isEqualTo(true);
         assertThat(testSubTopic.getResources()).hasSize(1);
 
@@ -67,15 +66,17 @@ class RoadMapCreateTest {
         RoadMap clonedRoadMap = rm.cloneAsIs(1);
 
         // then
-        clonedRoadMap.getTopics().forEach(t -> {
-            assertThat(rm.isDraft()).isFalse();
-            t.getSubTopics().forEach(s -> assertThat(s.getIsDraft()).isFalse());
-        });
+        clonedRoadMap
+                .getTopics()
+                .forEach(
+                        t -> {
+                            assertThat(rm.isDraft()).isFalse();
+                            t.getSubTopics().forEach(s -> assertThat(s.getIsDraft()).isFalse());
+                        });
 
         assertThat(clonedRoadMap.getTopics()).hasSize(2);
         assertThat(clonedRoadMap.getTopics().get(1).getSubTopics()).hasSize(1);
     }
-
 
     static CreationRoadMap testRoadMapBuilders(List<CreationTopic> topics) {
         return new CreationRoadMap(
@@ -84,8 +85,7 @@ class RoadMapCreateTest {
                 false,
                 1L,
                 1L,
-                topics
-        );
+                topics);
     }
 
     static List<CreationTopic> successTestTopicBuilders() {
@@ -97,9 +97,16 @@ class RoadMapCreateTest {
                         1,
                         false,
                         List.of(
-                                new CreationResourceTopic("Adoptium Temurin", ResourceType.OFFICIAL, 1, "https://adoptium.net/"),
-                                new CreationResourceTopic("Gradle User Guide", ResourceType.OFFICIAL, 2, "https://docs.gradle.org/current/userguide/userguide.html")
-                        ),
+                                new CreationResourceTopic(
+                                        "Adoptium Temurin",
+                                        ResourceType.OFFICIAL,
+                                        1,
+                                        "https://adoptium.net/"),
+                                new CreationResourceTopic(
+                                        "Gradle User Guide",
+                                        ResourceType.OFFICIAL,
+                                        2,
+                                        "https://docs.gradle.org/current/userguide/userguide.html")),
                         List.of(
                                 new CreationSubTopic(
                                         "프로젝트 스캐폴딩",
@@ -107,11 +114,11 @@ class RoadMapCreateTest {
                                         ImportanceLevel.DEFAULT,
                                         true,
                                         List.of(
-                                                new CreationResourceSubTopic("Spring Initializr", 1, ResourceType.OFFICIAL, "https://start.spring.io/")
-                                        )
-                                )
-                        )
-                ),
+                                                new CreationResourceSubTopic(
+                                                        "Spring Initializr",
+                                                        1,
+                                                        ResourceType.OFFICIAL,
+                                                        "https://start.spring.io/"))))),
                 new CreationTopic(
                         "REST API 설계",
                         "리소스 모델과 상태코드, 오류 응답",
@@ -119,9 +126,16 @@ class RoadMapCreateTest {
                         2,
                         false,
                         List.of(
-                                new CreationResourceTopic("RFC 9110 HTTP Semantics", ResourceType.OFFICIAL, 1, "https://www.rfc-editor.org/rfc/rfc9110"),
-                                new CreationResourceTopic("Richardson Maturity Model", ResourceType.POST, 2, "https://martinfowler.com/articles/richardsonMaturityModel.html")
-                        ),
+                                new CreationResourceTopic(
+                                        "RFC 9110 HTTP Semantics",
+                                        ResourceType.OFFICIAL,
+                                        1,
+                                        "https://www.rfc-editor.org/rfc/rfc9110"),
+                                new CreationResourceTopic(
+                                        "Richardson Maturity Model",
+                                        ResourceType.POST,
+                                        2,
+                                        "https://martinfowler.com/articles/richardsonMaturityModel.html")),
                         List.of(
                                 new CreationSubTopic(
                                         "에러 응답 규격",
@@ -129,20 +143,22 @@ class RoadMapCreateTest {
                                         ImportanceLevel.DEFAULT,
                                         false,
                                         List.of(
-                                                new CreationResourceSubTopic("RFC 7807 Problem Details", 1, ResourceType.OFFICIAL, "https://www.rfc-editor.org/rfc/rfc7807")
-                                        )
-                                ),
+                                                new CreationResourceSubTopic(
+                                                        "RFC 7807 Problem Details",
+                                                        1,
+                                                        ResourceType.OFFICIAL,
+                                                        "https://www.rfc-editor.org/rfc/rfc7807"))),
                                 new CreationSubTopic(
                                         "페이징과 정렬",
                                         "Cursor vs Offset",
                                         ImportanceLevel.OPTIONAL,
                                         true,
                                         List.of(
-                                                new CreationResourceSubTopic("Cursor Pagination 사례", 1, ResourceType.POST, "https://shopify.engineering/pagination-relative-cursors")
-                                        )
-                                )
-                        )
-                ),
+                                                new CreationResourceSubTopic(
+                                                        "Cursor Pagination 사례",
+                                                        1,
+                                                        ResourceType.POST,
+                                                        "https://shopify.engineering/pagination-relative-cursors"))))),
                 new CreationTopic(
                         "JPA와 영속성",
                         "엔티티 매핑, 트랜잭션, 성능",
@@ -150,10 +166,21 @@ class RoadMapCreateTest {
                         3,
                         true,
                         List.of(
-                                new CreationResourceTopic("Hibernate User Guide", ResourceType.OFFICIAL, 1, "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html"),
-                                new CreationResourceTopic("JPA 사양", ResourceType.OFFICIAL, 2, "https://jakarta.ee/specifications/persistence/"),
-                                new CreationResourceTopic("백엔드 로드맵 레퍼런스", ResourceType.ROADMAP, 3, "https://roadmap.sh/backend")
-                        ),
+                                new CreationResourceTopic(
+                                        "Hibernate User Guide",
+                                        ResourceType.OFFICIAL,
+                                        1,
+                                        "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html"),
+                                new CreationResourceTopic(
+                                        "JPA 사양",
+                                        ResourceType.OFFICIAL,
+                                        2,
+                                        "https://jakarta.ee/specifications/persistence/"),
+                                new CreationResourceTopic(
+                                        "백엔드 로드맵 레퍼런스",
+                                        ResourceType.ROADMAP,
+                                        3,
+                                        "https://roadmap.sh/backend")),
                         List.of(
                                 new CreationSubTopic(
                                         "지연 로딩과 N+1",
@@ -161,31 +188,42 @@ class RoadMapCreateTest {
                                         ImportanceLevel.RECOMMENDED,
                                         false,
                                         List.of(
-                                                new CreationResourceSubTopic("N+1 해결 가이드", 1, ResourceType.POST, "https://vladmihalcea.com/n-plus-1-query-problem/")
-                                        )
-                                ),
+                                                new CreationResourceSubTopic(
+                                                        "N+1 해결 가이드",
+                                                        1,
+                                                        ResourceType.POST,
+                                                        "https://vladmihalcea.com/n-plus-1-query-problem/"))),
                                 new CreationSubTopic(
                                         "트랜잭션 경계",
                                         "서비스 계층에서의 경계 설정",
                                         ImportanceLevel.PARALLEL,
                                         false,
                                         List.of(
-                                                new CreationResourceSubTopic("Spring Transaction 문서", 1, ResourceType.OFFICIAL, "https://docs.spring.io/spring-framework/reference/data-access/transaction.html"),
-                                                new CreationResourceSubTopic("실전 트랜잭션 전파", 2, ResourceType.POST, "https://spring.io/guides/gs/managing-transactions/")
-                                        )
-                                ),
+                                                new CreationResourceSubTopic(
+                                                        "Spring Transaction 문서",
+                                                        1,
+                                                        ResourceType.OFFICIAL,
+                                                        "https://docs.spring.io/spring-framework/reference/data-access/transaction.html"),
+                                                new CreationResourceSubTopic(
+                                                        "실전 트랜잭션 전파",
+                                                        2,
+                                                        ResourceType.POST,
+                                                        "https://spring.io/guides/gs/managing-transactions/"))),
                                 new CreationSubTopic(
                                         "엔티티 설계 원칙",
                                         "동등성, 식별자, 값 타입",
                                         ImportanceLevel.OPTIONAL,
                                         true,
                                         List.of(
-                                                new CreationResourceSubTopic("DDD Aggregates 소개", 1, ResourceType.POST, "https://martinfowler.com/bliki/DDD_Aggregate.html"),
-                                                new CreationResourceSubTopic("JPA 값 타입 정리", 2, ResourceType.POST, "https://www.baeldung.com/jpa-value-type")
-                                        )
-                                )
-                        )
-                )
-        );
+                                                new CreationResourceSubTopic(
+                                                        "DDD Aggregates 소개",
+                                                        1,
+                                                        ResourceType.POST,
+                                                        "https://martinfowler.com/bliki/DDD_Aggregate.html"),
+                                                new CreationResourceSubTopic(
+                                                        "JPA 값 타입 정리",
+                                                        2,
+                                                        ResourceType.POST,
+                                                        "https://www.baeldung.com/jpa-value-type"))))));
     }
 }

--- a/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapCreateTest.java
+++ b/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapCreateTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 
-class RoadMapDomainTest {
+class RoadMapCreateTest {
     @Test
     @DisplayName("로드맵 생성에 성공한다")
     void create_success() {

--- a/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapDomainTest.java
+++ b/src/test/java/com/kllhy/roadmap/roadmap/domain/model/RoadMapDomainTest.java
@@ -1,0 +1,191 @@
+package com.kllhy.roadmap.roadmap.domain.model;
+
+import com.kllhy.roadmap.roadmap.domain.model.creation_spec.*;
+import com.kllhy.roadmap.roadmap.domain.model.enums.ImportanceLevel;
+import com.kllhy.roadmap.roadmap.domain.model.enums.ResourceType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class RoadMapDomainTest {
+    @Test
+    @DisplayName("로드맵 생성에 성공한다")
+    void create_success() {
+        // given
+        var creationRoadMap = testRoadMapBuilders(successTestTopicBuilders());
+
+        // when
+        RoadMap rm = RoadMap.create(creationRoadMap);
+
+        // then
+        assertThat(rm.getTitle()).isEqualTo("Spring Backend Roadmap");
+        assertThat(rm.getDescription()).isEqualTo("Spring Boot, JPA, REST 설계 중심 로드맵");
+        assertThat(rm.isDraft()).isFalse();
+        assertThat(rm.getCategoryId()).isEqualTo(1L);
+
+        assertThat(rm.getTopics()).hasSize(3);
+        assertThat(rm.getTopics()).extracting(Topic::getOrder).containsExactly(1, 2, 3);
+        assertThat(rm.getTopics()).extracting(Topic::isDraft).containsExactly(false, false, true);
+
+        assertThat(rm.getTopics().get(0).getSubTopics()).hasSize(1);
+        assertThat(rm.getTopics().get(1).getSubTopics()).hasSize(2);
+        assertThat(rm.getTopics().get(2).getSubTopics()).hasSize(3);
+
+        var testSubTopic = rm.getTopics().get(0).getSubTopics().get(0);
+        assertThat(testSubTopic.getTitle()).isEqualTo("프로젝트 스캐폴딩");
+        assertThat(testSubTopic.getContent()).isEqualTo("start.spring.io 사용");
+        assertThat(testSubTopic.getImportanceLevel()).isEqualTo( ImportanceLevel.DEFAULT);
+        assertThat(testSubTopic.getIsDraft()).isEqualTo(true);
+        assertThat(testSubTopic.getResources()).hasSize(1);
+
+        assertThat(rm.getTopics().get(0).getResources()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("토픽이 없는 로드맵 생성에 실패한다")
+    void failToCreate_WhenNoTopics() {
+        // given
+        var creationRoadMap = testRoadMapBuilders(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> RoadMap.create(creationRoadMap))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("creationTopics 가 blank 임");
+    }
+
+    @Test
+    @DisplayName("로드맵 클론에 성공한다")
+    void clone_success() {
+        // given
+        var creationRoadMap = testRoadMapBuilders(successTestTopicBuilders());
+        RoadMap rm = RoadMap.create(creationRoadMap);
+
+        // when
+        RoadMap clonedRoadMap = rm.cloneAsIs(1);
+
+        // then
+        clonedRoadMap.getTopics().forEach(t -> {
+            assertThat(rm.isDraft()).isFalse();
+            t.getSubTopics().forEach(s -> assertThat(s.getIsDraft()).isFalse());
+        });
+
+        assertThat(clonedRoadMap.getTopics()).hasSize(2);
+        assertThat(clonedRoadMap.getTopics().get(1).getSubTopics()).hasSize(1);
+    }
+
+
+    static CreationRoadMap testRoadMapBuilders(List<CreationTopic> topics) {
+        return new CreationRoadMap(
+                "Spring Backend Roadmap",
+                "Spring Boot, JPA, REST 설계 중심 로드맵",
+                false,
+                1L,
+                1L,
+                topics
+        );
+    }
+
+    static List<CreationTopic> successTestTopicBuilders() {
+        return List.of(
+                new CreationTopic(
+                        "개발 환경",
+                        "JDK, Gradle, IDE 세팅",
+                        ImportanceLevel.RECOMMENDED,
+                        1,
+                        false,
+                        List.of(
+                                new CreationResourceTopic("Adoptium Temurin", ResourceType.OFFICIAL, 1, "https://adoptium.net/"),
+                                new CreationResourceTopic("Gradle User Guide", ResourceType.OFFICIAL, 2, "https://docs.gradle.org/current/userguide/userguide.html")
+                        ),
+                        List.of(
+                                new CreationSubTopic(
+                                        "프로젝트 스캐폴딩",
+                                        "start.spring.io 사용",
+                                        ImportanceLevel.DEFAULT,
+                                        true,
+                                        List.of(
+                                                new CreationResourceSubTopic("Spring Initializr", 1, ResourceType.OFFICIAL, "https://start.spring.io/")
+                                        )
+                                )
+                        )
+                ),
+                new CreationTopic(
+                        "REST API 설계",
+                        "리소스 모델과 상태코드, 오류 응답",
+                        ImportanceLevel.RECOMMENDED,
+                        2,
+                        false,
+                        List.of(
+                                new CreationResourceTopic("RFC 9110 HTTP Semantics", ResourceType.OFFICIAL, 1, "https://www.rfc-editor.org/rfc/rfc9110"),
+                                new CreationResourceTopic("Richardson Maturity Model", ResourceType.POST, 2, "https://martinfowler.com/articles/richardsonMaturityModel.html")
+                        ),
+                        List.of(
+                                new CreationSubTopic(
+                                        "에러 응답 규격",
+                                        "Problem+JSON 적용",
+                                        ImportanceLevel.DEFAULT,
+                                        false,
+                                        List.of(
+                                                new CreationResourceSubTopic("RFC 7807 Problem Details", 1, ResourceType.OFFICIAL, "https://www.rfc-editor.org/rfc/rfc7807")
+                                        )
+                                ),
+                                new CreationSubTopic(
+                                        "페이징과 정렬",
+                                        "Cursor vs Offset",
+                                        ImportanceLevel.OPTIONAL,
+                                        true,
+                                        List.of(
+                                                new CreationResourceSubTopic("Cursor Pagination 사례", 1, ResourceType.POST, "https://shopify.engineering/pagination-relative-cursors")
+                                        )
+                                )
+                        )
+                ),
+                new CreationTopic(
+                        "JPA와 영속성",
+                        "엔티티 매핑, 트랜잭션, 성능",
+                        ImportanceLevel.RECOMMENDED,
+                        3,
+                        true,
+                        List.of(
+                                new CreationResourceTopic("Hibernate User Guide", ResourceType.OFFICIAL, 1, "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html"),
+                                new CreationResourceTopic("JPA 사양", ResourceType.OFFICIAL, 2, "https://jakarta.ee/specifications/persistence/"),
+                                new CreationResourceTopic("백엔드 로드맵 레퍼런스", ResourceType.ROADMAP, 3, "https://roadmap.sh/backend")
+                        ),
+                        List.of(
+                                new CreationSubTopic(
+                                        "지연 로딩과 N+1",
+                                        "Fetch Join, Entity Graph",
+                                        ImportanceLevel.RECOMMENDED,
+                                        false,
+                                        List.of(
+                                                new CreationResourceSubTopic("N+1 해결 가이드", 1, ResourceType.POST, "https://vladmihalcea.com/n-plus-1-query-problem/")
+                                        )
+                                ),
+                                new CreationSubTopic(
+                                        "트랜잭션 경계",
+                                        "서비스 계층에서의 경계 설정",
+                                        ImportanceLevel.PARALLEL,
+                                        false,
+                                        List.of(
+                                                new CreationResourceSubTopic("Spring Transaction 문서", 1, ResourceType.OFFICIAL, "https://docs.spring.io/spring-framework/reference/data-access/transaction.html"),
+                                                new CreationResourceSubTopic("실전 트랜잭션 전파", 2, ResourceType.POST, "https://spring.io/guides/gs/managing-transactions/")
+                                        )
+                                ),
+                                new CreationSubTopic(
+                                        "엔티티 설계 원칙",
+                                        "동등성, 식별자, 값 타입",
+                                        ImportanceLevel.OPTIONAL,
+                                        true,
+                                        List.of(
+                                                new CreationResourceSubTopic("DDD Aggregates 소개", 1, ResourceType.POST, "https://martinfowler.com/bliki/DDD_Aggregate.html"),
+                                                new CreationResourceSubTopic("JPA 값 타입 정리", 2, ResourceType.POST, "https://www.baeldung.com/jpa-value-type")
+                                        )
+                                )
+                        )
+                )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- develop 변경 사항 반영 하면서 기존에 안되던 기능, dto와 매퍼, 테스트 코드 등 때문에 pr 한번에 많은 변경사항을 올리게 되었습니다 ㅠㅠ 죄송합니다 
- 로드맵의 생성, 클론, 조회 기능 추가

## Related Issue
- Issue Number: #38 #33
- (선택) Closes #33

## Changes
- 인증/인가를 하지 않기로 팀 내에서 의논 후 api request에 영향이 없도록 spring security를 삭제했습니다
- 공통 response를 생성한 뒤 controller response에서 사용했습니다
- ErrorCode와 별개로 SuccessCode를 정의했습니다
- 로드맵 생성과 클론 기능을 추가했습니다
- 레이어간 데이터 전달은 dto와 mapper를 사용했습니다
- 로드맵의 전체 데이터 조회가 불가능 했는데, 이 기능을 수정했습니다
- 로드맵 생성 성공, 실패, 클론에 대해 테스트 코드를 추가했습니다
  
## Discussion Topic
- Topic에서 hibernate bag 문제가 발생했습니다. batch size 만으로는 해결이 안되어 우선은 여러개의 쿼리로 로드맵의 세부 데이터들을 따로 조회한 뒤 영속성 컨텍스트에서 합치는 방식으로 구현되었습니다  #66 

### Screen Shot
- 로드맵 생성
<img width="994" height="822" alt="image" src="https://github.com/user-attachments/assets/7af0fade-aa1d-4bbf-a61b-49df676301a3" />

- 로드맵 클론
<img width="622" height="618" alt="image" src="https://github.com/user-attachments/assets/06bf2c94-9b61-4ed5-a5f2-b9bb7bd3f3ad" />

- 로드맵 조회
<img width="918" height="850" alt="image" src="https://github.com/user-attachments/assets/e301e56b-779d-4ce2-9cc1-20d66d44db1f" />

## Checklist
- [x] 로컬 테스트 완료
- [x] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음
