### PR TITLE
HOTFIX(roadMap): fix fatal error on `Topic`, `SubTopic` Entities soft delete

### DIFF
--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/RoadMap.java
@@ -75,6 +75,7 @@ public class RoadMap extends AggregateRoot {
     }
 
     public static RoadMap create(CreationRoadMap creationSpec) {
+        Objects.requireNonNull(creationSpec, "RoadMap.create: createSpec 이 null 입니다.");
 
         String title = creationSpec.title();
         validateTitle(title);
@@ -144,7 +145,7 @@ public class RoadMap extends AggregateRoot {
                             topics.add(Topic.create(spec));
                         });
 
-        topics.forEach(Topic::softDelete);
+        wouldBeRemovedTopic.values().forEach(Topic::softDelete);
         topics.sort(Comparator.comparing(Topic::getOrder));
         validateTopics(topics);
 

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/Topic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/Topic.java
@@ -239,16 +239,7 @@ public class Topic extends IdAuditEntity {
                                 existingResource.update(spec);
                             }
 
-                            ResourceTopic a = ResourceTopic.create(spec);
-                            try {
-                                ObjectMapper objectMapper = new ObjectMapper();
-                                objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-                                String prettyJson = objectMapper.writeValueAsString(a);
-                                System.out.println(prettyJson);
-                            } catch (Exception e) {
-                                e.printStackTrace();
-                            }
-                            resources.add(a);
+                            resources.add(ResourceTopic.create(spec));
                         });
 
         resources.removeAll(remainingResources.values());

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/Topic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/Topic.java
@@ -1,8 +1,6 @@
 package com.kllhy.roadmap.roadmap.domain.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.kllhy.roadmap.common.model.IdAuditEntity;
 import com.kllhy.roadmap.roadmap.domain.event.listener.TopicEntityListener;
 import com.kllhy.roadmap.roadmap.domain.model.creation_spec.CreationSubTopic;

--- a/src/main/java/com/kllhy/roadmap/roadmap/domain/model/Topic.java
+++ b/src/main/java/com/kllhy/roadmap/roadmap/domain/model/Topic.java
@@ -281,7 +281,7 @@ public class Topic extends IdAuditEntity {
                             subTopics.add(SubTopic.create(spec));
                         });
 
-        subTopics.forEach(SubTopic::softDelete);
+        wouldBeRemovedSubTopics.values().forEach(SubTopic::softDelete);
         validateSubTopicTitleUniqueness(subTopics);
 
         // 역방향 연결


### PR DESCRIPTION
## Summary
- `Topic`, `SubTopic` 엔티티 soft delete 시 치명적인 문제 해결

## Related Issue
- Issue Number: 

## Changes
- update 시 `Topic` 및 `SubTopic` 관계 리스트 전체를 soft delete 하는 문제 해결

## Checklist
- [x] 로컬 테스트 완료
- [ ] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음
